### PR TITLE
Automate docker images release process

### DIFF
--- a/.github/workflows/docker-admin-tools.yml
+++ b/.github/workflows/docker-admin-tools.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
+  release:
+    types:
+      - created
 
 jobs:
   publish_to_docker_hub:
@@ -13,17 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with: 
-          submodules: 'true'
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
         with:
-          images: temporaliotest/admin-tools
-          tags: |
-            type=sha,format=short,event=branch
-            type=semver,pattern={{version}}
+          submodules: "true"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -37,12 +29,42 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Docker meta for Commit image
+        id: meta_commit
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'push'
+        with:
+          images: temporaliotest/admin-tools
+          tags: |
+            type=sha,format=short,event=branch
+            # latest
+
+      - name: Push Commit image to DockerHub
         uses: docker/build-push-action@v2
+        if: github.event_name == 'push'
         with:
           push: true
           file: admin-tools.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_commit.outputs.tags }}
+          labels: ${{ steps.meta_commit.outputs.labels }}
+
+      - name: Docker meta for Release image
+        id: meta_release
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'release'
+        with:
+          images: temporalio/admin-tools
+          tags: |
+            type=semver,pattern={{version}}
+            # latest
+
+      - name: Push Release image to DockerHub
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'release'
+        with:
+          push: true
+          file: admin-tools.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_release.outputs.tags }}
+          labels: ${{ steps.meta_release.outputs.labels }}

--- a/.github/workflows/docker-auto-setup.yml
+++ b/.github/workflows/docker-auto-setup.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
+  release:
+    types:
+      - created
 
 jobs:
   publish_to_docker_hub:
@@ -13,17 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with: 
-          submodules: 'true'
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
         with:
-          images: temporaliotest/auto-setup
-          tags: |
-            type=sha,format=short,event=branch
-            type=semver,pattern={{version}}
+          submodules: "true"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -37,14 +29,46 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Docker meta for Commit image
+        id: meta_commit
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'push'
+        with:
+          images: temporaliotest/auto-setup
+          tags: |
+            type=sha,format=short,event=branch
+            # latest
+
+      - name: Push Commit image to DockerHub
         uses: docker/build-push-action@v2
+        if: github.event_name == 'push'
         with:
           push: true
           file: auto-setup.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_commit.outputs.tags }}
+          labels: ${{ steps.meta_commit.outputs.labels }}
+          build-args: |
+            GITHUB_SHA_SHORT=${{ $(echo $GITHUB_SHA | cut -c 1-8) }}
+
+      - name: Docker meta for Release image
+        id: meta_release
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'release'
+        with:
+          images: temporalio/auto-setup
+          tags: |
+            type=semver,pattern={{version}}
+            # latest
+
+      - name: Push Release image to DockerHub
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'release'
+        with:
+          push: true
+          file: auto-setup.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_release.outputs.tags }}
+          labels: ${{ steps.meta_release.outputs.labels }}
           build-args: |
             GITHUB_SHA_SHORT=${{ $(echo $GITHUB_SHA | cut -c 1-8) }}

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
+  release:
+    types:
+      - created
 
 jobs:
   publish_to_docker_hub:
@@ -13,17 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with: 
-          submodules: 'true'
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
         with:
-          images: temporaliotest/server
-          tags: |
-            type=sha,format=short,event=branch
-            type=semver,pattern={{version}}
+          submodules: "true"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -37,14 +29,46 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Docker meta for Commit image
+        id: meta_commit
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'push'
+        with:
+          images: temporaliotest/server
+          tags: |
+            type=sha,format=short,event=branch
+            # latest
+
+      - name: Push Commit image to DockerHub
         uses: docker/build-push-action@v2
+        if: github.event_name == 'push'
         with:
           push: true
           file: server.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_commit.outputs.tags }}
+          labels: ${{ steps.meta_commit.outputs.labels }}
+          build-args: |
+            GITHUB_SHA_SHORT=${{ $(echo $GITHUB_SHA | cut -c 1-8) }}
+
+      - name: Docker meta for Release image
+        id: meta_release
+        uses: docker/metadata-action@v3
+        if: github.event_name == 'release'
+        with:
+          images: temporalio/server
+          tags: |
+            type=semver,pattern={{version}}
+            # latest
+
+      - name: Push Release image to DockerHub
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'release'
+        with:
+          push: true
+          file: server.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_release.outputs.tags }}
+          labels: ${{ steps.meta_release.outputs.labels }}
           build-args: |
             GITHUB_SHA_SHORT=${{ $(echo $GITHUB_SHA | cut -c 1-8) }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Automates Release process:
 - On creating Releases from https://github.com/temporalio/docker-builds/releases page, this will trigger the pipelines and publish corresponding semver images [auto-setup, server, admin-tools] to https://hub.docker.com/r/temporalio/

## Why?
<!-- Tell your future self why have you made these changes -->

- Simplifies release process
- Supports ARM (and M1 macs)
- Includes new tctl https://github.com/temporalio/tctl
- Gives visibility into releases to external users

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

~ mostly through testing the same process on ui-server https://github.com/temporalio/ui-server/releases/tag/v0.2.0

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
