### PR TITLE
Upgrade go to 1.17.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,2 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
+.idea
+.vscode

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.6.0
 ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.3.0
 ARG GOPROXY
 

--- a/auto-setup.Dockerfile
+++ b/auto-setup.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.5.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.6.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.6.0
 ARG GOPROXY
 
 ##### Builder #####

--- a/develop.Dockerfile
+++ b/develop.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.5.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.6.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.6.0
 ARG GOPROXY
 
 ##### Builder #####

--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,5 +1,4 @@
-# alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-FROM golang:1.17.3-alpine3.13 AS base-builder
+FROM golang:1.17.6-alpine3.15 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,6 +1,4 @@
-# alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-# Buildkite elastic stack needs to be upgraded to the version which has docker 20.10.0 (at least).
-FROM golang:1.17.3-alpine3.13 AS base-ci-builder
+FROM golang:1.17.6-alpine3.15 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,6 +1,5 @@
 ##### dockerize builder: built from source to support arm & x86 #####
-# alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-FROM golang:1.17.3-alpine3.13 AS dockerize-builder
+FROM golang:1.17.6-alpine3.15 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.5.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.6.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.6.0
 ARG GOPROXY
 
 ##### Builder #####


### PR DESCRIPTION
Upgrade go version to the latest 1.17.6 to close https://github.com/temporalio/temporal/issues/2451.