### PR TITLE
Commit into main instead of master

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -28,17 +28,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Calc target branches
+        id: target_branches
+        env:
+          LOCAL_BRANCH: ${{ github.event.inputs.branch }}
+          SUBMODULE_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          if [[ $LOCAL_BRANCH == master ]]; then LOCAL_BRANCH=main; fi
+          echo "::set-output name=local_branch::$LOCAL_BRANCH"
+          echo "::set-output name=submodule_branch::$SUBMODULE_BRANCH"
+
       - name: Create and switch branch
         env:
-          BRANCH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ steps.target_branches.outputs.local_branch }}
         run: |
-          if [[ $BRANCH == master ]]; then BRANCH=main; fi
           git switch "$BRANCH" || git switch -c "$BRANCH"
 
       - name: Update Submodule branch
         env:
           SUBMODULE: ${{ github.event.inputs.repo }}
-          BRANCH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ steps.target_branches.outputs.submodule_branch }}
         run: |
           git config --file=.gitmodules submodule."$SUBMODULE".branch "$BRANCH"
           git submodule update --init --recursive --remote
@@ -48,11 +57,11 @@ jobs:
           CURRENT_REPO: ${{ github.repository }}
           TOKEN: ${{ secrets.COMMANDER_DATA_TOKEN }}
           SUBMODULE: ${{ github.event.inputs.repo }}
-          BRANCH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ steps.target_branches.outputs.local_branch }}
         run: |
           git config --local user.name 'Temporal Data (cicd)'
           git config --local user.email 'commander-data@temporal.io'
           git remote set-url origin "https://x-access-token:$TOKEN@github.com/$CURRENT_REPO"
           git add .
           git commit -m "Update $SUBMODULE submodule for branch $BRANCH"
-          git push origin "$BRANCH" || echo "No changes to commit"
+          git push origin "$BRANCH"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Commits into `main` instead of `master` when the input BRANCH == 'master'
- Stops hiding error if push is unsuccessful

## Why?
<!-- Tell your future self why have you made these changes -->

on Temporal updates, it was trying to commit into master
```
git push origin master
error: src refspec master does not match any
error: failed to push some refs to 'https://github.com/temporalio/docker-builds'
```
https://github.com/temporalio/docker-builds/runs/5210816039?check_suite_focus=true#step:5:17

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
