### PR TITLE
Removing vim, verified vi is available

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -6,7 +6,6 @@ RUN apk add --update --no-cache \
     tzdata \
     bash \
     curl \
-    vim \
     jq \
     mysql-client \
     postgresql-client \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -18,8 +18,7 @@ RUN apk add --update --no-cache \
     ca-certificates \
     tzdata \
     bash \
-    curl \
-    vim
+    curl
 
 COPY --from=dockerize-builder /usr/local/bin/dockerize /usr/local/bin/dockerize
 # set up nsswitch.conf for Go's "netgo" implementation


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removing vim from base container images

## Why?
<!-- Tell your future self why have you made these changes -->
CVE
confirmed `vi` is still available _**if**_ needed.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#28 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Confirmed through local docker run/exec/build

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No