### PR TITLE
Create Release pipeline for base-* images

### DIFF
--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -1,0 +1,56 @@
+name: Release Base-* Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target base image"
+        type: choice
+        options:
+        - base-server
+        - base-builder
+        - base-admin-tools
+        - base-ci-builder
+        required: true
+      commit:
+        description: "Commit sha to build from"
+        required: true
+      tag:
+        description: "New tag for the image"
+        required: true
+
+jobs:
+  build-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Metatags for the image
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: temporalio/${{ github.event.inputs.target }}
+
+      - name: Build-Push Base-* image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: docker/base-images/${{ github.event.inputs.target }}.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ github.event.inputs.tag }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added a pipeline to release base-* image

Accepts:
* target - Target base image, one of: base-server, base-builder, base-ci-builder, base-admin-tools
* commit - Commit sha to build from
* tag - New tag for the image

## Why?
<!-- Tell your future self why have you made these changes -->

Automating release process

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

executed the script using `nektos/act`
```
[Release Base-* Docker image/build-push-images]   ❓  ::endgroup::
[Release Base-* Docker image/build-push-images]   ✅  Success - Build-Push Server image
```

in progress

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
