### PR TITLE
Remove explicit CGO_ENABLED=0

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -14,7 +14,7 @@ RUN (cd ./temporal && go mod download all)
 
 # build
 COPY . .
-RUN (cd ./temporal && CGO_ENABLED=0 make temporal-cassandra-tool temporal-sql-tool)
+RUN (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool)
 
 
 ##### Server #####

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -18,7 +18,7 @@ RUN (cd ./tctl && go mod download all)
 
 # build
 COPY . .
-RUN (cd ./temporal && CGO_ENABLED=0 make temporal-server)
+RUN (cd ./temporal && make temporal-server)
 RUN (cd ./tctl && make build)
 
 ##### Temporal server #####


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Explicit `CGO_ENABLED=0` is removed because it is set by default https://github.com/temporalio/temporal/pull/2760.


