### PR TITLE
TLS support for postgreSQL

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -36,6 +36,11 @@ set -eux -o pipefail
 : "${POSTGRES_USER:=}"
 : "${POSTGRES_PWD:=}"
 
+: "${SQL_TLS_ENABLED:=false}"
+: "${SQL_CERT:=}"
+: "${SQL_CERT_KEY:=}"
+: "${SQL_CA:=}"
+
 # Elasticsearch
 : "${ENABLE_ES:=false}"
 : "${ES_SCHEME:=http}"
@@ -199,17 +204,17 @@ setup_postgres_schema() {
     SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/temporal/versioned
     # Create database only if its name is different from the user name. Otherwise PostgreSQL container itself will create database.
     if [[ ${DBNAME} != "${POSTGRES_USER}" && ${SKIP_DB_CREATE} != true ]]; then
-        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --tls=${SQL_TLS_ENABLED} create --db "${DBNAME}"
     fi
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" --tls=${SQL_TLS_ENABLED} setup-schema -v 0.0
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" --tls=${SQL_TLS_ENABLED} update-schema -d "${SCHEMA_DIR}"
 
     VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/visibility/versioned
     if [[ ${VISIBILITY_DBNAME} != "${POSTGRES_USER}" && ${SKIP_DB_CREATE} != true ]]; then
-        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --tls=${SQL_TLS_ENABLED} create --db "${VISIBILITY_DBNAME}"
     fi
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" --tls=${SQL_TLS_ENABLED} setup-schema -v 0.0
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" --tls=${SQL_TLS_ENABLED} update-schema -d "${VISIBILITY_SCHEMA_DIR}"
 }
 
 setup_schema() {


### PR DESCRIPTION
## What was changed
This is to enable TLS support for postgreSQL. 
Add `--tls=${SQL_TLS_ENABLED}` for queries in `setup_postgres_schema` method

## Why?
Currently, the connection from temporal to DB is not a SSL connection. Please find the error below when connecting to a SSL enforced database.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/docker-builds/issues/59

2. How was this tested:
Tested with a SSL enforced PostgreSQL server and a non SSL enforced PostgreSQL server. 
This does not break the current flow. This adds the support for TLS enabled connections

3. Any docs updates needed? No
