### PR TITLE
Upgrade base images to use alpine:3.16

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15 AS base-admin-tools
+FROM alpine:3.16 AS base-admin-tools
 
 RUN apk add --update --no-cache \
     ca-certificates \

--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.15 AS base-builder
+FROM golang:1.18-alpine3.16 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.15 AS base-ci-builder
+FROM golang:1.18-alpine3.16 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,5 +1,5 @@
 ##### dockerize builder: built from source to support arm & x86 #####
-FROM golang:1.18-alpine3.15 AS dockerize-builder
+FROM golang:1.18-alpine3.16 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git
@@ -11,7 +11,7 @@ RUN mkdir -p /xsrc && \
     rm -rf /xsrc
 
 ##### base-server target #####
-FROM alpine:3.15 AS base-server
+FROM alpine:3.16 AS base-server
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Upgrade base images to use `alpine:3.16`.

## Why?
<!-- Tell your future self why have you made these changes -->
To address security concerns.
