### PR TITLE
Remove python2 dependency from base-admin-tools

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -8,8 +8,7 @@ RUN apk add --update --no-cache \
     jq \
     mysql-client \
     postgresql-client \
-    python2 \
-    && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python \
+    py-pip \
     && pip install cqlsh
 
 # set up nsswitch.conf for Go's "netgo" implementation


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Remove `python2` dependency from `base-admin-tools`.

## Why?
<!-- Tell your future self why have you made these changes -->
`python2` was removed from alpine 3.16: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0.
