### PR TITLE
Fix entrypoint when running in IPv6

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-: "${BIND_ON_IP:=$(hostname -i)}"
+: "${BIND_ON_IP:=$(getent hosts $(hostname) | awk '{print $1;}')}"
 export BIND_ON_IP
 
 if [[ "${BIND_ON_IP}" =~ ":" ]]; then


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Use `getent hosts ${hostname}` instead of `hostname -i` to resolve our own IP address.

## Why?
There appears to be a [bug with busybox](https://bugs.busybox.net/show_bug.cgi?id=15056) on Alpine where `hostname -i` throws a "Host not found" error when running on a pod in a k8s cluster using IPv6 -- using `getent hosts` instead correctly resolves the IP address.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Successfully spun up a working Temporal cluster in an IPv6 k8s cluster after applying this change. Without this change, pods would start successfully, but workflows could not be started.

3. Any docs updates needed?
no
