### PR TITLE
Bump go version to 1.19 on the base images

### DIFF
--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS base-builder
+FROM golang:1.19-alpine3.16 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS base-ci-builder
+FROM golang:1.19-alpine3.16 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,5 +1,5 @@
 ##### dockerize builder: built from source to support arm & x86 #####
-FROM golang:1.18-alpine3.16 AS dockerize-builder
+FROM golang:1.19-alpine3.16 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bump go version to 1.19 on the base images.
These images are used as a base to build other images.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
