### PR TITLE
Upgrade expat in admin-tools

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -24,6 +24,10 @@ FROM ${SERVER_IMAGE} as server
 ##### Temporal admin tools #####
 FROM ${BASE_ADMIN_TOOLS_IMAGE} as temporal-admin-tools
 
+# upgrade just this one for CVE-2022-40674
+RUN apk add --update --no-cache --upgrade \
+    expat
+
 WORKDIR /etc/temporal
 
 COPY --from=server /usr/local/bin/tctl /usr/local/bin


### PR DESCRIPTION
## What was changed
Upgrade just this one package in admin-tools directly on release branch, so that we don't pull in other changes to base images.

## Why?
CVE-2022-40674

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
local build, verify expat version
