### PR TITLE
Use BuildJet instead of GitHub-hosted larger runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-push-multi-arch-images:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: buildjet-16vcpu-ubuntu-2204
     strategy:
       matrix:
         arch: ["linux/amd64,linux/arm64"]
@@ -63,7 +63,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-push-amd64-images:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: buildjet-16vcpu-ubuntu-2204
     strategy:
       matrix:
         arch: [linux/amd64]

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed GitHub runners to BuildJet.

## Why?
BuildJet is 2x cheaper than GitHub-hosted runners.
https://buildjet.com/for-github-actions/docs/runners

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

2. How was this tested:
CI

3. Any docs updates needed?
No