### PR TITLE
Upgrade GitHub Actions to use Environment Files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           github_sha_short=${GITHUB_SHA:0:7}
           push=${{ github.event_name == 'push' && !env.ACT }}
-          echo "::set-output name=commit_sha_short::$github_sha_short"
-          echo "::set-output name=image_tag::sha-$github_sha_short"
-          echo "::set-output name=push::$push"
+          echo "commit_sha_short=${github_sha_short}" >> $GITHUB_OUTPUT
+          echo "image_tag=sha-${github_sha_short}" >> $GITHUB_OUTPUT
+          echo "push=${push}" >> $GITHUB_OUTPUT
 
 ### BUILD & PUSH SERVER IMAGE ###
 

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           COMMIT: ${{ github.event.inputs.commit }}
         run: |
-          echo "::set-output name=image_tag::sha-${COMMIT:0:7}"
+          echo "image_tag=sha-${COMMIT:0:7}" >> $GITHUB_OUTPUT
 
       - name: Copy images
         env:

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -35,8 +35,8 @@ jobs:
           SUBMODULE_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           if [[ $LOCAL_BRANCH == master ]]; then LOCAL_BRANCH=main; fi
-          echo "::set-output name=local_branch::$LOCAL_BRANCH"
-          echo "::set-output name=submodule_branch::$SUBMODULE_BRANCH"
+          echo "local_branch=${LOCAL_BRANCH}" >> $GITHUB_OUTPUT
+          echo "submodule_branch=${SUBMODULE_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Create and switch branch
         env:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Upgraded GitHub Actions to use Environment Files

## Why?
The `set-output` command is deprecated and will be disabled soon. Upgraded to use Environment Files.
For more information, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

3. How was this tested:
CI

4. Any docs updates needed?
No