### PR TITLE
Bump base docker images

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.10.0
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.8.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.11.0
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.9.0
 ARG SERVER_IMAGE
 ARG GOPROXY
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.10.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.11.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.11.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.12.0
 ARG GOPROXY
 
 ##### Builder #####


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped base-builder image to 1.11.0
Bumped base-server image to 1.12.0
Bumped base-admin-tools image to 1.9.0

## Why?
Address security vulnerabilities:
```
temporalio/base-builder:1.10.0 (alpine 3.16.2)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 3, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ expat   │ CVE-2022-43680 │ HIGH     │ 2.4.9-r0          │ 2.5.0-r0      │ In libexpat through 2.4.9, there is a use-after free caused │
│         │                │          │                   │               │ by overeag...                                               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43680                  │
├─────────┼────────────────┤          ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ git     │ CVE-2022-39260 │          │ 2.36.2-r0         │ 2.36.3-r0     │ git: git shell function that splits command arguments can   │
│         │                │          │                   │               │ lead to arbitrary...                                        │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-39260                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-39253 │ MEDIUM   │                   │               │ git: exposure of sensitive information to a malicious actor │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-39253                  │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcurl │ CVE-2022-42915 │ CRITICAL │ 7.83.1-r3         │ 7.83.1-r4     │ curl: HTTP proxy double-free                                │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42915                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-42916 │ HIGH     │                   │               │ curl: HSTS bypass via IDN                                   │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42916                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-32221 │ MEDIUM   │                   │               │ curl: POST following PUT confusion                          │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-32221                  │
└─────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```
```
temporalio/base-admin-tools:1.8.0 (alpine 3.16.2)

Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 3, CRITICAL: 2)

┌─────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ curl    │ CVE-2022-42915 │ CRITICAL │ 7.83.1-r3         │ 7.83.1-r4     │ curl: HTTP proxy double-free                                │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42915                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-42916 │ HIGH     │                   │               │ curl: HSTS bypass via IDN                                   │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42916                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-32221 │ MEDIUM   │                   │               │ curl: POST following PUT confusion                          │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-32221                  │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ expat   │ CVE-2022-43680 │ HIGH     │ 2.4.9-r0          │ 2.5.0-r0      │ In libexpat through 2.4.9, there is a use-after free caused │
│         │                │          │                   │               │ by overeag...                                               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43680                  │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcurl │ CVE-2022-42915 │ CRITICAL │ 7.83.1-r3         │ 7.83.1-r4     │ curl: HTTP proxy double-free                                │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42915                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-42916 │ HIGH     │                   │               │ curl: HSTS bypass via IDN                                   │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42916                  │
│         ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2022-32221 │ MEDIUM   │                   │               │ curl: POST following PUT confusion                          │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-32221                  │
└─────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```
```
temporalio/base-server:1.11.0 (alpine 3.16.2)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 2, CRITICAL: 2)

┌─────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                   Title                    │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────┤
│ curl    │ CVE-2022-42915 │ CRITICAL │ 7.83.1-r3         │ 7.83.1-r4     │ curl: HTTP proxy double-free               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42915 │
│         ├────────────────┼──────────┤                   │               ├────────────────────────────────────────────┤
│         │ CVE-2022-42916 │ HIGH     │                   │               │ curl: HSTS bypass via IDN                  │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42916 │
│         ├────────────────┼──────────┤                   │               ├────────────────────────────────────────────┤
│         │ CVE-2022-32221 │ MEDIUM   │                   │               │ curl: POST following PUT confusion         │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-32221 │
├─────────┼────────────────┼──────────┤                   │               ├────────────────────────────────────────────┤
│ libcurl │ CVE-2022-42915 │ CRITICAL │                   │               │ curl: HTTP proxy double-free               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42915 │
│         ├────────────────┼──────────┤                   │               ├────────────────────────────────────────────┤
│         │ CVE-2022-42916 │ HIGH     │                   │               │ curl: HSTS bypass via IDN                  │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-42916 │
│         ├────────────────┼──────────┤                   │               ├────────────────────────────────────────────┤
│         │ CVE-2022-32221 │ MEDIUM   │                   │               │ curl: POST following PUT confusion         │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-32221 │
└─────────┴────────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────┘
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

3. How was this tested:
Trivy, CI

4. Any docs updates needed?
No