### PR TITLE
Update image tagging to follow semantic versioning

### DIFF
--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -49,12 +49,21 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set tags
+        env:
+          TAGS: ${{ github.event.inputs.tag }}
+        id: vars
+        shell: bash
+        run: |
+          tags=$(echo "$TAGS" | awk -F \. '{print $1; print $1"."$2; print $0}')
+          echo "tags=${tags}" >> $GITHUB_OUTPUT
+
       - name: Metatags for the image
         id: meta
         uses: docker/metadata-action@v3
         with:
           images: temporalio/${{ github.event.inputs.target }}
-          tags: ${{ github.event.inputs.tag }}
+          tags: ${{ steps.vars.outputs.tags }}
 
       - name: Build-Push Base-* image
         uses: docker/build-push-action@v2
@@ -62,5 +71,5 @@ jobs:
           push: true
           file: docker/base-images/${{ github.event.inputs.target }}.Dockerfile
           platforms: ${{ github.event.inputs.arch }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.vars.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -71,5 +71,5 @@ jobs:
           push: true
           file: docker/base-images/${{ github.event.inputs.target }}.Dockerfile
           platforms: ${{ github.event.inputs.arch }}
-          tags: ${{ steps.vars.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated image tagging to follow semantic versioning.

## Why?
The current approach of not reusing tags and not following Image semantic versioning creates friction for image security patches as they require a new Temporal Server release.
This change enables us to reuse tags for security patches and use image semantic versioning for simple image upgrades.

After this change, we will start releasing "base-image" security and other patches using the `patch` version. For example:  for the existing `temporalio/base-server:1.12.0` image, after we release a patch, we will update these tags:
```
temporalio/base-server:1.12.<patch>
temporalio/base-server:1.12
temporalio/base-server:1
```
Then users can use `FROM temporalio/base-server:1.12` to use the latest `minor` or other version.

After this change, we will also update production image tagging.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CI

3. Any docs updates needed?
todo
