### PR TITLE
Use semantic versioning tags for release images

### DIFF
--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -19,48 +19,20 @@ jobs:
   retag-and-release:
     name: "Re-tag and release images"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
-      - name: Calc image tag from commit sha
-        id: calc_args
-        env:
-          COMMIT: ${{ github.event.inputs.commit }}
-          TAGS: ${{ github.event.inputs.tag }}
-        run: |
-          echo "image_tag=sha-${COMMIT:0:7}" >> $GITHUB_OUTPUT
-          tags=$(awk -v v="$TAGS" 'BEGIN { while(v ~ /\./) {print v; gsub(/\.([^\.]+)$/, "", v)}; print v}')
-          echo "tags<<TAGS_EOF" >> $GITHUB_OUTPUT
-          echo "${tags}" >> $GITHUB_OUTPUT
-          echo "TAGS_EOF" >> $GITHUB_OUTPUT
-
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'src/go.mod'
       - name: Copy images
         env:
+          COMMIT: ${{ github.event.inputs.commit }}
+          TAG: ${{ github.event.inputs.tag }}
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
           PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           IMAGES: server auto-setup admin-tools
           SRC_REPO: temporaliotest
           DST_REPO: temporalio
-          SRC_TAG: ${{ steps.calc_args.outputs.image_tag }}
-          DST_TAGS: ${{ steps.calc_args.outputs.tags }}
           LATEST: ${{ github.event.inputs.latest }}
-        run: |
-          skopeo() {
-            docker run --rm -i quay.io/skopeo/stable "$@"
-          }
-
-          for image in ${IMAGES}; do
-            src="docker://${SRC_REPO}/${image}:${SRC_TAG}"
-
-            for tag in ${DST_TAGS}; do
-              dst="docker://${DST_REPO}/${image}:${tag}"
-              skopeo copy --dest-creds="$USERNAME":"$PASSWORD" --all "$src" "$dst"
-            done
-
-            if [[ "$LATEST" == "true" ]]; then
-              dst_latest="docker://${DST_REPO}/${image}:latest"
-              skopeo copy --dest-creds="$USERNAME":"$PASSWORD" --all "$src" "$dst_latest"
-            fi
-          done
+        run: go run src/release_temporal/main.go

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -28,8 +28,13 @@ jobs:
         id: calc_args
         env:
           COMMIT: ${{ github.event.inputs.commit }}
+          TAGS: ${{ github.event.inputs.tag }}
         run: |
           echo "image_tag=sha-${COMMIT:0:7}" >> $GITHUB_OUTPUT
+          tags=$(awk -v v="$TAGS" 'BEGIN { while(v ~ /\./) {print v; gsub(/\.([^\.]+)$/, "", v)}; print v}')
+          echo "tags<<TAGS_EOF" >> $GITHUB_OUTPUT
+          echo "${tags}" >> $GITHUB_OUTPUT
+          echo "TAGS_EOF" >> $GITHUB_OUTPUT
 
       - name: Copy images
         env:
@@ -39,7 +44,7 @@ jobs:
           SRC_REPO: temporaliotest
           DST_REPO: temporalio
           SRC_TAG: ${{ steps.calc_args.outputs.image_tag }}
-          DST_TAG: ${{ github.event.inputs.tag }}
+          DST_TAGS: ${{ steps.calc_args.outputs.tags }}
           LATEST: ${{ github.event.inputs.latest }}
         run: |
           skopeo() {
@@ -48,8 +53,11 @@ jobs:
 
           for image in ${IMAGES}; do
             src="docker://${SRC_REPO}/${image}:${SRC_TAG}"
-            dst="docker://${DST_REPO}/${image}:${DST_TAG}"
-            skopeo copy --dest-creds="$USERNAME":"$PASSWORD" --all "$src" "$dst"
+
+            for tag in ${DST_TAGS}; do
+              dst="docker://${DST_REPO}/${image}:${tag}"
+              skopeo copy --dest-creds="$USERNAME":"$PASSWORD" --all "$src" "$dst"
+            done
 
             if [[ "$LATEST" == "true" ]]; then
               dst_latest="docker://${DST_REPO}/${image}:latest"

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,11 @@
+module docker_builds
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/release_temporal/main.go
+++ b/src/release_temporal/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Env struct {
+	srcTag       string
+	dstTags      []string
+	images       []string
+	username     string
+	password     string
+	srcRepo      string
+	dstRepo      string
+	setLatestTag bool
+}
+
+func loadEnv() *Env {
+	commit := getEnv("COMMIT")
+	return &Env{
+		srcTag:       fmt.Sprintf("sha-%s", commit[0:7]),
+		dstTags:      getTags(getEnv("TAG")),
+		images:       strings.Split(getEnv("IMAGES"), " "),
+		username:     getEnv("USERNAME"),
+		password:     getEnv("PASSWORD"),
+		srcRepo:      getEnv("SRC_REPO"),
+		dstRepo:      getEnv("DST_REPO"),
+		setLatestTag: os.Getenv("LATEST") != "",
+	}
+}
+
+func getEnv(key string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		log.Fatalf("Required env %q not set\n", key)
+	}
+	return val
+}
+
+func skopeo(arguments []string) {
+	args := []string{"run", "--rm", "-i", "quay.io/skopeo/stable"}
+	args = append(args, arguments...)
+	cmd := exec.Command("docker", args...)
+	stdout, err := cmd.CombinedOutput()
+	log.Println(string(stdout))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func getTags(dstTag string) []string {
+	versions := strings.Split(dstTag, ".")
+	vv := versions[0]
+	tags := []string{vv}
+	for _, v := range versions[1:] {
+		vv += "." + v
+		tags = append(tags, vv)
+	}
+	return tags
+}
+
+func copyImages() {
+	env := loadEnv()
+
+	for _, image := range env.images {
+		src := fmt.Sprintf("docker://%s/%s:%s", env.srcRepo, image, env.srcTag)
+
+		for _, tag := range env.dstTags {
+			dst := fmt.Sprintf("docker://%s/%s:%s", env.dstRepo, image, tag)
+			skopeo([]string{"copy", "--dest-creds=$USERNAME:$PASSWORD", "--all", src, dst})
+		}
+
+		if env.setLatestTag {
+			dst_latest := fmt.Sprintf("docker://%s/%s:latest", env.dstRepo, image)
+			creds := fmt.Sprintf("--dest-creds=%s:%s", env.username, env.password)
+			skopeo([]string{"copy", creds, "--all", src, dst_latest})
+		}
+	}
+}
+
+func main() {
+	copyImages()
+}

--- a/src/release_temporal/main_test.go
+++ b/src/release_temporal/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGetTags(t *testing.T) {
+	assert := assert.New(t)
+	tests := map[string]struct {
+		tag      string
+		expected []string
+	}{
+		"Version 1": {
+			tag:      "0.12.345.6789",
+			expected: []string{"0", "0.12", "0.12.345", "0.12.345.6789"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(tt.expected, getTags(tt.tag))
+		})
+	}
+}
+
+func TestLoadEnv(t *testing.T) {
+	assert := assert.New(t)
+	tests := map[string]struct {
+		init     func()
+		expected *Env
+	}{
+		"Env 1": {
+			init: func() {
+				os.Setenv("COMMIT", "7757792ebdff55590a32823c948f1c027d8c3652")
+				os.Setenv("TAG", "0.12.345.6789")
+				os.Setenv("IMAGES", "image-1 image-2")
+				os.Setenv("USERNAME", "username")
+				os.Setenv("PASSWORD", "password")
+				os.Setenv("SRC_REPO", "test-repo")
+				os.Setenv("DST_REPO", "release-repo")
+				os.Setenv("LATEST", "1")
+			},
+			expected: &Env{
+				srcTag:       "sha-7757792",
+				dstTags:      []string{"0", "0.12", "0.12.345", "0.12.345.6789"},
+				images:       []string{"image-1", "image-2"},
+				username:     "username",
+				password:     "password",
+				srcRepo:      "test-repo",
+				dstRepo:      "release-repo",
+				setLatestTag: true,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			os.Clearenv()
+			tt.init()
+			assert.Equal(tt.expected, loadEnv())
+		})
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated image tagging to follow semantic versioning: `<major>.<minor>.<patch>.<security>`

## Why?
The current approach of not reusing tags and not following Image semantic versioning creates friction for image security patches as they require a new Temporal Server release.
This change enables us to reuse tags for security patches and use image semantic versioning for simple image upgrades.

After this change, we will start releasing security and other patches using the `security` version. For example: for the existing `temporalio/server:1.18.4` image, after we release a security patch, we will update these tags:
```
temporalio/server:1.18.4.<security>
temporalio/server:1.18.4
temporalio/server:1.18
temporalio/server:1
```
Then users can continue using `FROM temporalio/server:1.18.4` to get the latest security patches.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Unit tests

3. Any docs updates needed?
Todo