### PR TITLE
Revert "Use BuildJet instead of GitHub-hosted larger runners (#77)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-push-multi-arch-images:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
         arch: ["linux/amd64,linux/arm64"]
@@ -63,7 +63,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-push-amd64-images:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
         arch: [linux/amd64]

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit 5097fe65b2bc6fc1f6e2c8e90ae0a1370c6479d2.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Revert "Use BuildJet instead of GitHub-hosted larger runners (https://github.com/temporalio/docker-builds/pull/77)"

## Why?
BuildJet is unreliable.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
3. How was this tested:
CI
4. Any docs updates needed?
No