### PR TITLE
Avoid 10 seconds delay on admin-tools container termination

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -50,4 +50,4 @@ COPY --from=admin-tools-builder /home/builder/temporal/schema /etc/temporal/sche
 COPY --from=admin-tools-builder /home/builder/temporal/tdbg /usr/local/bin
 
 # Keep the container running.
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+ENTRYPOINT ["tini", "--", "sleep", "infinity"]

--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update --no-cache \
     postgresql-client \
     py-pip \
     expat \
+    tini \
     && pip install cqlsh
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
## What was changed
- Added `tini` to admin-tools's entrypoint

## Why?
- Avoid 10 seconds delay on admin-tools container termination, due to incorrect SIGTERM handling by busybox's `tail` command (see below image for behavior before this PR)

![Previous termination behaviour](https://user-images.githubusercontent.com/6412169/202496092-99610a40-fa9b-4228-9979-c014ccd26d61.png)

More context
```
This is likely the result of the PID 1 signaling issue.

Inside a PID namespace the first process launched gets PID 1.
PID 1 is treated special by the kernel in that the default signal actions are to ignore, instead of exit.
Meaning that unless the application installs a signal handler,
SIGINT and SIGTERM won't cause the application to exit. (see http://lwn.net/Articles/532748/)

tail is a very basic utility, and does not install any signal handlers, so it ignores them.
The only thing that will kill it is SIGKILL (which is what docker stop will do after the 10 second timeout)
```

## Checklist
1. How was this tested: built and ran affected image locally

2. Any docs updates needed? No.