### PR TITLE
Add Temporal CLI to docker images

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = tctl
 	url = https://github.com/temporalio/tctl
 	branch = main
+[submodule "cli"]
+	path = cli
+	url = https://github.com/temporalio/cli

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ DOCKER_BUILDX_OUTPUT ?= image
 
 TEMPORAL_ROOT := temporal
 TCTL_ROOT := tctl
+TEMPORAL_CLI_ROOT := cli
 
 ##### Scripts ######
 install: install-submodules
@@ -20,11 +21,11 @@ update: update-submodules
 
 install-submodules:
 	@printf $(COLOR) "Installing temporal and tctl submodules..."
-	git submodule update --init $(TEMPORAL_ROOT) $(TCTL_ROOT)
+	git submodule update --init $(TEMPORAL_ROOT) $(TCTL_ROOT) $(TEMPORAL_CLI_ROOT)
 
 update-submodules:
 	@printf $(COLOR) "Updatinging temporal and tctl submodules..."
-	git submodule update --force --remote $(TEMPORAL_ROOT) $(TCTL_ROOT)
+	git submodule update --force --remote $(TEMPORAL_ROOT) $(TCTL_ROOT) $(TEMPORAL_CLI_ROOT)
 
 ##### Docker #####
 docker-server:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added `temporal` CLI into the Docker images

## Why?
<!-- Tell your future self why have you made these changes -->

distribution of the new cli

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

verified that `server`, `admin-tools` and `auto-setup` images have `temporal` executable under `/usr/local/bin`. Also that `temporal` is in the PATH 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
