### PR TITLE
Remove default SERVICES var

### DIFF
--- a/docker/start-temporal.sh
+++ b/docker/start-temporal.sh
@@ -3,13 +3,14 @@
 set -eu -o pipefail
 
 : "${SERVICES:=}"
-: "${SERVICE_FLAGS:=}"
 
-if [[ -z ${SERVICE_FLAGS}  && -n ${SERVICES} ]]; then
-    # Convert semicolon (or comma, for backward compatibility) separated string (i.e. "history:matching")
+flags=()
+if [[ -n ${SERVICES} ]]; then
+    # Convert colon (or comma, for backward compatibility) separated string (i.e. "history:matching")
     # to valid flag list (i.e. "--service=history --service=matching").
-    IFS=':,' read -ra SERVICE_FLAGS <<< "${SERVICES}"
-    for i in "${!SERVICE_FLAGS[@]}"; do SERVICE_FLAGS[$i]="--service=${SERVICE_FLAGS[$i]}"; done
+    SERVICES="${SERVICES//:/,}"
+    SERVICES="${SERVICES//,/ }"
+    for i in $SERVICES; do flags+=("--service=$i"); done
 fi
 
-exec temporal-server --env docker start "${SERVICE_FLAGS[@]}"
+exec temporal-server --env docker start "${flags[@]}"

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -29,7 +29,7 @@ FROM ${BASE_SERVER_IMAGE} as temporal-server
 
 WORKDIR /etc/temporal
 
-ENV TEMPORAL_HOME /etc/temporal
+ENV TEMPORAL_HOME=/etc/temporal
 EXPOSE 6933 6934 6935 6939 7233 7234 7235 7239
 
 # TODO switch WORKDIR to /home/temporal and remove "mkdir" and "chown" calls.

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -30,7 +30,6 @@ FROM ${BASE_SERVER_IMAGE} as temporal-server
 WORKDIR /etc/temporal
 
 ENV TEMPORAL_HOME /etc/temporal
-ENV SERVICES "history:matching:frontend:worker"
 EXPOSE 6933 6934 6935 6939 7233 7234 7235 7239
 
 # TODO switch WORKDIR to /home/temporal and remove "mkdir" and "chown" calls.


### PR DESCRIPTION
## What was changed
- Remove the default for `SERVICES` env var, so that the server will use its own internal default (all configured services).
- Rewrite the logic in `start-temporal.sh` so it works without `SERVICES` set.

## Why?
We want to be able to have one docker image that can run with internal-frontend, or not, depending on the config. This lets the server binary handle the default service set instead of hardcoding it here.

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested:
manual testing

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
