### PR TITLE
Add 30 mins timeout for the Docker images job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   build-push-images:
     runs-on: ubuntu-latest-16-cores
+    # Usually, a successful job takes ~17 mins.
+    # Anything more than 30 mins is a sign that job is stuck.
+    # This is a workaround until we find the root cause.
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added default timeout for the Docker Images job

## Why?
Sometimes this job gets stuck for an unknown reason and is canceled by the default timeout, which is 360 mins (6 hours).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

2. How was this tested:
CI

3. Any docs updates needed?
No