### PR TITLE
auto-setup: check TEMPORAL_CLI_ADDRESS before setting it up

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,12 +5,17 @@ set -eu -o pipefail
 : "${BIND_ON_IP:=$(getent hosts $(hostname) | awk '{print $1;}')}"
 export BIND_ON_IP
 
-if [[ "${BIND_ON_IP}" =~ ":" ]]; then
-    # ipv6
-    export TEMPORAL_CLI_ADDRESS="[${BIND_ON_IP}]:7233"
-else
-    # ipv4
-    export TEMPORAL_CLI_ADDRESS="${BIND_ON_IP}:7233"
+# check TEMPORAL_CLI_ADDRESS is not empty
+if [[ -z "${TEMPORAL_CLI_ADDRESS:-}" ]]; then
+    echo "TEMPORAL_CLI_ADDRESS is not set, setting it to ${BIND_ON_IP}:7233"
+
+    if [[ "${BIND_ON_IP}" =~ ":" ]]; then
+        # ipv6
+        export TEMPORAL_CLI_ADDRESS="[${BIND_ON_IP}]:7233"
+    else
+        # ipv4
+        export TEMPORAL_CLI_ADDRESS="${BIND_ON_IP}:7233"
+    fi
 fi
 
 dockerize -template /etc/temporal/config/config_template.yaml:/etc/temporal/config/docker.yaml


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a check for TEMPORAL_CLI_ADDRESS before setting it up.

## Why?
It will be pointed to a different container for a multi-role setup.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Locally
3. Any docs updates needed?
No