### PR TITLE
Remove nsswitch.conf workaround

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -12,8 +12,4 @@ RUN apk add --update --no-cache \
     expat \
     && pip install cqlsh
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
-RUN test ! -e /etc/nsswitch.conf && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 SHELL ["/bin/bash", "-c"]

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -20,8 +20,5 @@ RUN apk add --update --no-cache \
     curl
 
 COPY --from=dockerize-builder /usr/local/bin/dockerize /usr/local/bin/dockerize
-# set up nsswitch.conf for Go's "netgo" implementation
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
-RUN test ! -e /etc/nsswitch.conf && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removed nsswitch.conf workaround for Alpine <3.16

## Why?
Alpine 3.17 includes the file /etc/nsswitch.conf
```
% docker run --rm -it alpine:3.16 ls -l /etc/nsswitch.conf
ls: /etc/nsswitch.conf: No such file or directory

% docker run --rm -it alpine:3.17 ls -l /etc/nsswitch.conf
-rw-r--r--    1 root     root           205 Nov  4 14:43 /etc/nsswitch.conf

% docker run --rm -it alpine:3.17 cat /etc/nsswitch.conf
# musl itself does not support NSS, however some third-party DNS
# implementations use the nsswitch.conf file to determine what
# policy to follow.
# Editing this file is not recommended.
hosts: files dns
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
```
make base-server
make base-builder
make base-admin-tools
```

3. Any docs updates needed?
No