### PR TITLE
Bump base image versions

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.11.0
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.9.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.12.0
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.10.0
 ARG SERVER_IMAGE
 ARG GOPROXY
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.11.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.12.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.12.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.13.0
 
 ##### Builder #####
 FROM ${BASE_BUILDER_IMAGE} AS temporal-builder


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped base-builder image to 1.12.0
Bumped base-server image to 1.13.0
Bumped base-admin-tools image to 1.10.0

## Why?
Periodic maintenance.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CI

3. Any docs updates needed?
No