### PR TITLE
Sleep after namespace registration to refresh cache

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -288,15 +288,12 @@ register_default_namespace() {
     else
         echo "Default namespace ${DEFAULT_NAMESPACE} already registered."
     fi
+
+    echo "Waiting for namespace cache to refresh (sleeping for 10 seconds)..."
+    sleep 10
 }
 
 add_custom_search_attributes() {
-    until temporal operator search-attribute list --namespace "${DEFAULT_NAMESPACE}"; do
-      echo "Waiting for namespace cache to refresh..."
-      sleep 1
-    done
-    echo "Namespace cache refreshed."
-
     echo "Adding Custom*Field search attributes."
     # TODO: Remove CustomStringField
 # @@@SNIPSTART add-custom-search-attributes-for-testing-command


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `sleep 10` to wait for namespace cache to refresh.

## Why?
<!-- Tell your future self why have you made these changes -->
Sleeping 10 seconds is the only safe way to ensure all namespace caches are refreshed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
