### PR TITLE
Update temporal search-attribute command

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -312,7 +312,7 @@ add_custom_search_attributes() {
     echo "Adding Custom*Field search attributes."
     # TODO: Remove CustomStringField
 # @@@SNIPSTART add-custom-search-attributes-for-testing-command
-    temporal operator search-attribute create --namespace "${DEFAULT_NAMESPACE}" --yes \
+    temporal operator search-attribute create \
         --name CustomKeywordField --type Keyword \
         --name CustomStringField --type Text \
         --name CustomTextField --type Text \

--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -312,7 +312,7 @@ add_custom_search_attributes() {
     echo "Adding Custom*Field search attributes."
     # TODO: Remove CustomStringField
 # @@@SNIPSTART add-custom-search-attributes-for-testing-command
-    temporal operator search-attribute create \
+    temporal operator search-attribute create --namespace "${DEFAULT_NAMESPACE}" \
         --name CustomKeywordField --type Keyword \
         --name CustomStringField --type Text \
         --name CustomTextField --type Text \


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated temporal CLI command.
Removed not defined the `--yes` option.

## Why?
Before:
```
$ temporal operator search-attribute create --namespace "${DEFAULT_NAMESPACE}" --yes \
        --name CustomKeywordField --type Keyword \
        --name CustomStringField --type Text \
        --name CustomTextField --type Text \
        --name CustomIntField --type Int \
        --name CustomDatetimeField --type Datetime \
        --name CustomDoubleField --type Double \
        --name CustomBoolField --type Bool
Incorrect Usage: flag provided but not defined: -yes
```
After:
```
$ temporal operator search-attribute create --namespace "${DEFAULT_NAMESPACE}" \
        --name CustomKeywordField --type Keyword \
        --name CustomStringField --type Text \
        --name CustomTextField --type Text \
        --name CustomIntField --type Int \
        --name CustomDatetimeField --type Datetime \
        --name CustomDoubleField --type Double \
        --name CustomBoolField --type Bool
Search attributes have been added
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Locally

3. Any docs updates needed?
Revert