### PR TITLE
Replace Temporal CLI build with official release version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,3 @@
 	path = tctl
 	url = https://github.com/temporalio/tctl
 	branch = main
-[submodule "cli"]
-	path = cli
-	url = https://github.com/temporalio/cli
-	branch = main

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ DOCKER_BUILDX_OUTPUT ?= image
 
 TEMPORAL_ROOT := temporal
 TCTL_ROOT := tctl
-TEMPORAL_CLI_ROOT := cli
 
 ##### Scripts ######
 install: install-submodules
@@ -21,11 +20,11 @@ update: update-submodules
 
 install-submodules:
 	@printf $(COLOR) "Installing temporal and tctl submodules..."
-	git submodule update --init $(TEMPORAL_ROOT) $(TCTL_ROOT) $(TEMPORAL_CLI_ROOT)
+	git submodule update --init $(TEMPORAL_ROOT) $(TCTL_ROOT)
 
 update-submodules:
 	@printf $(COLOR) "Updatinging temporal and tctl submodules..."
-	git submodule update --force --remote $(TEMPORAL_ROOT) $(TCTL_ROOT) $(TEMPORAL_CLI_ROOT)
+	git submodule update --force --remote $(TEMPORAL_ROOT) $(TCTL_ROOT)
 
 ##### Docker #####
 docker-server:

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -12,10 +12,6 @@ WORKDIR /home/builder
 COPY ./temporal/go.mod ./temporal/go.sum ./temporal/
 RUN (cd ./temporal && go mod download all)
 
-# cache Temporal CLI packages as a docker layer
-COPY ./cli/go.mod ./cli/go.sum ./cli/
-RUN (cd ./cli && go mod download all)
-
 # build
 COPY ./temporal ./temporal
 # Git info is needed for Go build to attach VCS information properly.
@@ -23,9 +19,6 @@ COPY ./temporal ./temporal
 COPY ./.git ./.git
 COPY ./.gitmodules ./.gitmodules
 RUN (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool tdbg)
-
-COPY ./cli ./cli
-RUN (cd ./cli && make build)
 
 
 ##### Server #####

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -14,9 +14,9 @@ RUN (cd ./temporal && go mod download all)
 COPY ./tctl/go.mod ./tctl/go.sum ./tctl/
 RUN (cd ./tctl && go mod download all)
 
-# cache Temporal CLI binary
-RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli
-RUN mv ./cli/bin/temporal ./cli/
+# install Temporal CLI
+RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli && \
+    mv ./cli/bin/temporal ./cli/
 
 # build
 COPY ./tctl ./tctl

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE=builder-temp:latest
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.13.1
 ARG BASE_SERVER_IMAGE=temporalio/base-server:1.14.1
 
 ##### Builder #####
@@ -15,7 +15,7 @@ COPY ./tctl/go.mod ./tctl/go.sum ./tctl/
 RUN (cd ./tctl && go mod download all)
 
 # cache Temporal CLI binary
-RUN set -e; curl -sSf https://temporal.download/cli.sh | sh /dev/stdin --dir ./cli
+RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli
 RUN mv ./cli/bin/temporal ./cli/
 
 # build

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,8 +1,9 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.13.1
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.13.2
 ARG BASE_SERVER_IMAGE=temporalio/base-server:1.14.1
 
 ##### Builder #####
 FROM ${BASE_BUILDER_IMAGE} AS temporal-builder
+ARG TEMPORAL_CLI_VERSION=latest
 
 WORKDIR /home/builder
 
@@ -15,7 +16,7 @@ COPY ./tctl/go.mod ./tctl/go.sum ./tctl/
 RUN (cd ./tctl && go mod download all)
 
 # install Temporal CLI
-RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli && \
+RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli --version "$TEMPORAL_CLI_VERSION" && \
     mv ./cli/bin/temporal ./cli/
 
 # build


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Started installing the official latest CLI version instead of building on spot
- Removed CLI submodule

## Why?
<!-- Tell your future self why have you made these changes -->

Consistency with the CLI releases, proper correlation when addressing support questions

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Built an image locally and verified `temporal` command is available
- Verified that `which temporal` returns the same value 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
