### PR TITLE
Save component versions in ENV variables

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,9 +45,9 @@ jobs:
 
           TEMPORAL_SHA=$(git submodule status -- temporal | awk '{print $1}')
           echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_OUTPUT
-          TCTL_SHA=$(git submodule status -- temporal | awk '{print $1}')
+          TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
           echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_OUTPUT
-          CLI_SHA=$(git submodule status -- temporal | awk '{print $1}')
+          CLI_SHA=$(git submodule status -- cli | awk '{print $1}')
           echo "CLI_SHA=${CLI_SHA}" >> $GITHUB_OUTPUT
 
 ### BUILD & PUSH SERVER IMAGE ###

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,13 @@ jobs:
           echo "image_tag=sha-${github_sha_short}" >> $GITHUB_OUTPUT
           echo "push=${push}" >> $GITHUB_OUTPUT
 
+          TEMPORAL_SHA=$(git submodule status -- temporal | awk '{print $1}')
+          echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_OUTPUT
+          TCTL_SHA=$(git submodule status -- temporal | awk '{print $1}')
+          echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_OUTPUT
+          CLI_SHA=$(git submodule status -- temporal | awk '{print $1}')
+          echo "CLI_SHA=${CLI_SHA}" >> $GITHUB_OUTPUT
+
 ### BUILD & PUSH SERVER IMAGE ###
 
       - name: Metatags for the Server image
@@ -60,6 +67,10 @@ jobs:
           context: .
           push: ${{ steps.build_args.outputs.push }}
           file: server.Dockerfile
+          build-args: |
+            TEMPORAL_SHA: ${{ steps.build_args.outputs.TEMPORAL_SHA }}
+            TCTL_SHA: ${{ steps.build_args.outputs.TCTL_SHA }}
+            CLI_SHA: ${{ steps.build_args.outputs.CLI_SHA }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_server.outputs.tags }}
           labels: ${{ steps.meta_server.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ TEMPORAL_ROOT := temporal
 TCTL_ROOT := tctl
 TEMPORAL_CLI_ROOT := cli
 
+TEMPORAL_SHA := $(shell sh -c 'git submodule status -- temporal | cut -c2-40')
+TCTL_SHA := $(shell sh -c "git submodule status -- tctl | cut -c2-40")
+CLI_SHA := $(shell sh -c "git submodule status -- cli | cut -c2-40")
+SERVER_BUILD_ARGS := --build-arg TEMPORAL_SHA=$(TEMPORAL_SHA) --build-arg TCTL_SHA=$(TCTL_SHA) --build-arg CLI_SHA=$(CLI_SHA)
+
 ##### Scripts ######
 install: install-submodules
 
@@ -30,7 +35,7 @@ update-submodules:
 ##### Docker #####
 docker-server:
 	@printf $(COLOR) "Building docker image temporalio/server:$(DOCKER_IMAGE_TAG)..."
-	docker build . -f server.Dockerfile -t temporalio/server:$(DOCKER_IMAGE_TAG)
+	docker build . -f server.Dockerfile -t temporalio/server:$(DOCKER_IMAGE_TAG) $(SERVER_BUILD_ARGS)
 
 docker-admin-tools: docker-server
 	@printf $(COLOR) "Build docker image temporalio/admin-tools:$(DOCKER_IMAGE_TAG)..."
@@ -45,7 +50,7 @@ docker-buildx-container:
 
 docker-server-x:
 	@printf $(COLOR) "Building cross-platform docker image temporalio/server:$(DOCKER_IMAGE_TAG)..."
-	docker buildx build . -f server.Dockerfile -t temporalio/server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT)
+	docker buildx build . -f server.Dockerfile -t temporalio/server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) $(SERVER_BUILD_ARGS)
 
 docker-admin-tools-x: docker-server-x
 	@printf $(COLOR) "Build cross-platform docker image temporalio/admin-tools:$(DOCKER_IMAGE_TAG)..."

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -32,6 +32,9 @@ RUN (cd ./cli && make build)
 
 ##### Temporal server #####
 FROM ${BASE_SERVER_IMAGE} as temporal-server
+ARG TEMPORAL_SHA=unknown
+ARG TCTL_SHA=unknown
+ARG CLI_SHA=unknown
 
 WORKDIR /etc/temporal
 
@@ -44,6 +47,11 @@ RUN adduser -u 1000 -G temporal -D temporal
 RUN mkdir /etc/temporal/config
 RUN chown -R temporal:temporal /etc/temporal/config
 USER temporal
+
+# store component versions in the environment
+ENV TEMPORAL_SHA=${TEMPORAL_SHA}
+ENV TCTL_SHA=${TCTL_SHA}
+ENV CLI_SHA=${CLI_SHA}
 
 # binaries
 COPY --from=temporal-builder /home/builder/tctl/tctl /usr/local/bin


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added Env variables with components versions:
```
$ make docker-server
...

$ docker inspect docker.io/temporalio/server:latest | jq '.[].Config.Env'
[
  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
  "TEMPORAL_HOME=/etc/temporal",
  "TEMPORAL_SHA=1a479ad802abf3fc2de735ee3535a625fef5bc5",
  "TCTL_SHA=46f3e20e26434e142f320a215be4ce21ba643a0",
  "CLI_SHA=7c42c704522ad64ad7f3934538e3500dc175792"
]

$ git submodule status
 7c42c704522ad64ad7f3934538e3500dc1757924 cli (v0.6.0-1-g7c42c70)
 46f3e20e26434e142f320a215be4ce21ba643a01 tctl (v1.18.0-2-g46f3e20)
 1a479ad802abf3fc2de735ee3535a625fef5bc5d temporal (v1.13.0-1564-g1a479ad80)

$ docker run --rm -it --entrypoint env docker.io/temporalio/server:latest
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=866eba4267c3
TERM=xterm
TEMPORAL_HOME=/etc/temporal
TEMPORAL_SHA=1a479ad802abf3fc2de735ee3535a625fef5bc5
TCTL_SHA=46f3e20e26434e142f320a215be4ce21ba643a0
CLI_SHA=7c42c704522ad64ad7f3934538e3500dc175792
HOME=/home/temporal
```

## Why?
For debugging and easier to discover installed component versions.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Locally, CI

3. Any docs updates needed?
No