### PR TITLE
Fix GHA GITHUB_OUTPUT variable

### DIFF
--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -63,7 +63,7 @@ jobs:
           BUMP: ${{ github.event.inputs.bump }}
         run: |
           tag=$(cd src; go run image_tags/main.go -org temporalio -repo "$REPO" bump "$BUMP")
-          echo "tag=$tag\n" >> $GITHUB_OUTPUT
+          echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Metatags for the image
         id: meta


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removed unnecessary new line.

## Why?
```
ERROR: invalid tag "temporalio/base-ci-builder:1.9.2\\n": invalid reference format
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CI

3. Any docs updates needed?
No