### PR TITLE
Fix release-all-base-images GHA martix options

### DIFF
--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -27,11 +27,12 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
-        arch: ["linux/amd64, linux/arm64"]
-        image: [base-server, base-builder, base-admin-tools, base-ci-builder]
-        exclude:
-          # don't build arm64 images for base-ci-builder
-          - arch: linux/arm64
+        # note this arch represents a single matrix option, see quotes
+        arch: ["linux/amd64,linux/arm64"]
+        image: [base-server, base-builder, base-admin-tools]
+        include:
+          # build only amd64 image for base-ci-builder 
+          - arch: linux/amd64
             image: base-ci-builder
 
     steps:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated matrix options

## Why?
By mistake, the arch option `"linux/amd64,linux/arm64"` was treated as two separate options.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
GHA

3. Any docs updates needed?
No