### PR TITLE
Rename TEMPORAL_CLI_ADDRESS to TEMPORAL_ADDRESS

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -49,7 +49,7 @@ set -eux -o pipefail
 : "${ES_SCHEMA_SETUP_TIMEOUT_IN_SECONDS:=0}"
 
 # Server setup
-: "${TEMPORAL_CLI_ADDRESS:=}"
+: "${TEMPORAL_ADDRESS:=}"
 
 : "${SKIP_DEFAULT_NAMESPACE_CREATION:=false}"
 : "${DEFAULT_NAMESPACE:=default}"
@@ -329,7 +329,7 @@ add_custom_search_attributes() {
 }
 
 setup_server(){
-    echo "Temporal CLI address: ${TEMPORAL_CLI_ADDRESS}."
+    echo "Temporal CLI address: ${TEMPORAL_ADDRESS}."
 
     until temporal operator cluster health | grep -q SERVING; do
         echo "Waiting for Temporal server to start..."

--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -50,6 +50,8 @@ set -eux -o pipefail
 
 # Server setup
 : "${TEMPORAL_ADDRESS:=}"
+# TEMPORAL_CLI_ADDRESS is deprecated and support for it will be removed in the future release.
+: "${TEMPORAL_CLI_ADDRESS:=}"
 
 : "${SKIP_DEFAULT_NAMESPACE_CREATION:=false}"
 : "${DEFAULT_NAMESPACE:=default}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,6 +18,12 @@ if [[ -z "${TEMPORAL_ADDRESS:-}" ]]; then
     fi
 fi
 
+# Support TEMPORAL_CLI_ADDRESS for backwards compatibility.
+# TEMPORAL_CLI_ADDRESS is deprecated and support for it will be removed in the future release.
+if [[ -z "${TEMPORAL_CLI_ADDRESS:-}" ]]; then
+    export TEMPORAL_CLI_ADDRESS="${TEMPORAL_ADDRESS}"
+fi
+
 dockerize -template /etc/temporal/config/config_template.yaml:/etc/temporal/config/docker.yaml
 
 # Automatically setup Temporal Server (databases, Elasticsearch, default namespace) if "autosetup" is passed as an argument.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,16 +5,16 @@ set -eu -o pipefail
 : "${BIND_ON_IP:=$(getent hosts $(hostname) | awk '{print $1;}')}"
 export BIND_ON_IP
 
-# check TEMPORAL_CLI_ADDRESS is not empty
-if [[ -z "${TEMPORAL_CLI_ADDRESS:-}" ]]; then
-    echo "TEMPORAL_CLI_ADDRESS is not set, setting it to ${BIND_ON_IP}:7233"
+# check TEMPORAL_ADDRESS is not empty
+if [[ -z "${TEMPORAL_ADDRESS:-}" ]]; then
+    echo "TEMPORAL_ADDRESS is not set, setting it to ${BIND_ON_IP}:7233"
 
     if [[ "${BIND_ON_IP}" =~ ":" ]]; then
         # ipv6
-        export TEMPORAL_CLI_ADDRESS="[${BIND_ON_IP}]:7233"
+        export TEMPORAL_ADDRESS="[${BIND_ON_IP}]:7233"
     else
         # ipv4
-        export TEMPORAL_CLI_ADDRESS="${BIND_ON_IP}:7233"
+        export TEMPORAL_ADDRESS="${BIND_ON_IP}:7233"
     fi
 fi
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
`TEMPORAL_CLI_ADDRESS` is deprecated, and its support will be removed in the future release.
Support both `TEMPORAL_CLI_ADDRESS` and `TEMPORAL_ADDRESS`.

## Why?
The latest Temporal CLI has renamed those variables: https://github.com/temporalio/cli/releases/tag/v0.9.0

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No