### PR TITLE
Remove CLI_SHA as it is not used anymore

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,8 +47,6 @@ jobs:
           echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_OUTPUT
           TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
           echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_OUTPUT
-          CLI_SHA=$(git submodule status -- cli | awk '{print $1}')
-          echo "CLI_SHA=${CLI_SHA}" >> $GITHUB_OUTPUT
 
 ### BUILD & PUSH SERVER IMAGE ###
 
@@ -70,7 +68,6 @@ jobs:
           build-args: |
             TEMPORAL_SHA=${{ steps.build_args.outputs.TEMPORAL_SHA }}
             TCTL_SHA=${{ steps.build_args.outputs.TCTL_SHA }}
-            CLI_SHA=${{ steps.build_args.outputs.CLI_SHA }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_server.outputs.tags }}
           labels: ${{ steps.meta_server.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ TCTL_ROOT := tctl
 
 TEMPORAL_SHA := $(shell sh -c 'git submodule status -- temporal | cut -c2-40')
 TCTL_SHA := $(shell sh -c "git submodule status -- tctl | cut -c2-40")
-CLI_SHA := $(shell sh -c "git submodule status -- cli | cut -c2-40")
-SERVER_BUILD_ARGS := --build-arg TEMPORAL_SHA=$(TEMPORAL_SHA) --build-arg TCTL_SHA=$(TCTL_SHA) --build-arg CLI_SHA=$(CLI_SHA)
+SERVER_BUILD_ARGS := --build-arg TEMPORAL_SHA=$(TEMPORAL_SHA) --build-arg TCTL_SHA=$(TCTL_SHA)
 
 ##### Scripts ######
 install: install-submodules

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -33,7 +33,6 @@ RUN (cd ./tctl && make build)
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TEMPORAL_SHA=unknown
 ARG TCTL_SHA=unknown
-ARG CLI_SHA=unknown
 
 WORKDIR /etc/temporal
 
@@ -50,7 +49,6 @@ USER temporal
 # store component versions in the environment
 ENV TEMPORAL_SHA=${TEMPORAL_SHA}
 ENV TCTL_SHA=${TCTL_SHA}
-ENV CLI_SHA=${CLI_SHA}
 
 # binaries
 COPY --from=temporal-builder /home/builder/tctl/tctl /usr/local/bin


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removed `CLI_SHA` env var from docker images.

## Why?
After the CLI installation change, It's not used anymore.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No