### PR TITLE
Fix tagging command and add tests

### DIFF
--- a/src/image_tags/main_test.go
+++ b/src/image_tags/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	assert := assert.New(t)
+
+	getAllTags = func(org, repo string) Tags {
+		return Tags{
+			Tags: []string{
+				"0.0.1",
+				"0.0.2",
+				"0.2.23",
+				"0.2.3",
+				"latest",
+			},
+		}
+	}
+
+	latest := getLatestTag("org", "repo")
+	assert.Equal("0.2.23", latest)
+
+	bumpPatch := bumpVersion(latest, "patch")
+	assert.Equal("0.2.24", bumpPatch)
+
+	bumpMinor := bumpVersion(latest, "minor")
+	assert.Equal("0.3.0", bumpMinor)
+
+	bumpMajor := bumpVersion(latest, "major")
+	assert.Equal("1.0.0", bumpMajor)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed tagging command.
Added tests.

## Why?
Bugfix
```
Run tag=$(cd src; go run image_tags/main.go -org temporalio -repo "$REPO" bump "$BUMP")
  tag=$(cd src; go run image_tags/main.go -org temporalio -repo "$REPO" bump "$BUMP")
  echo "tag=$tag" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
  env:
    REPO: base-admin-tools
    BUMP: minor
go: downloading github.com/Masterminds/semver/v3 v3.2.1
2023/06/12 19:14:22 Error parsing version: Invalid Semantic Version
exit status 1
```

It was failing for the version string `latest`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
GHA

3. Any docs updates needed?
No