### PR TITLE
Enable bash competion for temporal cli in admin-tools

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -30,8 +30,9 @@ FROM ${BASE_ADMIN_TOOLS_IMAGE} as temporal-admin-tools
 
 WORKDIR /etc/temporal
 
-RUN addgroup -g 1000 temporal
-RUN adduser -u 1000 -G temporal -D temporal
+RUN echo "source <(temporal completion bash)" > /etc/bash/temporal-completion.sh && \
+    addgroup -g 1000 temporal && \
+    adduser -u 1000 -G temporal -D temporal
 USER temporal
 
 COPY --from=server /usr/local/bin/tctl /usr/local/bin

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -17,7 +17,7 @@ RUN (cd ./tctl && go mod download all)
 
 # install Temporal CLI
 RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli --version "$TEMPORAL_CLI_VERSION" && \
-    mv ./cli/bin/temporal ./cli/
+    mv ./cli/bin/temporal ./cli/ && chown 0:0 ./cli/temporal
 
 # build
 COPY ./tctl ./tctl


### PR DESCRIPTION
## What was changed
- Enable bash competion for temporal cli in admin-tools
- Combine a few RUN lines into one
- Fix ownership of temporal binary

## Why?
Make using admin-tools more pleasant

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
manually (local docker build)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
