### PR TITLE
Update image tagging to support previous release patching

### DIFF
--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -14,6 +14,11 @@ on:
         description: "Also update latest tag"
         required: true
         default: false
+      major:
+        type: boolean
+        description: "Also update major tag"
+        required: true
+        default: false
 
 jobs:
   retag-and-release:
@@ -35,4 +40,5 @@ jobs:
           SRC_REPO: temporaliotest
           DST_REPO: temporalio
           LATEST: ${{ github.event.inputs.latest }}
+          MAJOR: ${{ github.event.inputs.major }}
         run: go run src/release_temporal/main.go

--- a/src/release_temporal/main.go
+++ b/src/release_temporal/main.go
@@ -21,15 +21,16 @@ type Env struct {
 
 func loadEnv() *Env {
 	commit := getEnv("COMMIT")
+	updateMajor := os.Getenv("MAJOR") == "true"
 	return &Env{
 		srcTag:       fmt.Sprintf("sha-%s", commit[0:7]),
-		dstTags:      getTags(getEnv("TAG")),
+		dstTags:      getTags(getEnv("TAG"), updateMajor),
 		images:       strings.Split(getEnv("IMAGES"), " "),
 		username:     getEnv("USERNAME"),
 		password:     getEnv("PASSWORD"),
 		srcRepo:      getEnv("SRC_REPO"),
 		dstRepo:      getEnv("DST_REPO"),
-		setLatestTag: os.Getenv("LATEST") != "",
+		setLatestTag: os.Getenv("LATEST") == "true",
 	}
 }
 
@@ -52,10 +53,13 @@ func skopeo(arguments []string) {
 	}
 }
 
-func getTags(dstTag string) []string {
+func getTags(dstTag string, updateMajor bool) []string {
 	versions := strings.Split(dstTag, ".")
 	vv := versions[0]
-	tags := []string{vv}
+	var tags []string
+	if updateMajor {
+		tags = []string{vv}
+	}
 	for _, v := range versions[1:] {
 		vv += "." + v
 		tags = append(tags, vv)

--- a/src/release_temporal/main_test.go
+++ b/src/release_temporal/main_test.go
@@ -9,18 +9,25 @@ import (
 func TestGetTags(t *testing.T) {
 	assert := assert.New(t)
 	tests := map[string]struct {
-		tag      string
-		expected []string
+		tag         string
+		updateMajor bool
+		expected    []string
 	}{
 		"Version 1": {
-			tag:      "0.12.345.6789",
-			expected: []string{"0", "0.12", "0.12.345", "0.12.345.6789"},
+			tag:         "0.12.345.6789",
+			updateMajor: true,
+			expected:    []string{"0", "0.12", "0.12.345", "0.12.345.6789"},
+		},
+		"Version 2": {
+			tag:         "1.23.456.7890",
+			updateMajor: false,
+			expected:    []string{"1.23", "1.23.456", "1.23.456.7890"},
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(tt.expected, getTags(tt.tag))
+			assert.Equal(tt.expected, getTags(tt.tag, tt.updateMajor))
 		})
 	}
 }
@@ -40,7 +47,8 @@ func TestLoadEnv(t *testing.T) {
 				os.Setenv("PASSWORD", "password")
 				os.Setenv("SRC_REPO", "test-repo")
 				os.Setenv("DST_REPO", "release-repo")
-				os.Setenv("LATEST", "1")
+				os.Setenv("LATEST", "true")
+				os.Setenv("MAJOR", "true")
 			},
 			expected: &Env{
 				srcTag:       "sha-7757792",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed `latest` image updating.
Added support for updating major image tags.

## Why?
During the previous release patching, we don't want to update the `latest` tag together with the major tag `1`. 

I.e., if we have the previous release of `1.20.3` and the latest release of `1.21.1`, then our docker images would point as such:
```
latest - v1.21.1
1      - v1.21.1
1.21   - v1.21.1
1.21.1 - v1.21.1
1.20   - v1.20.3
1.20.3 - v1.20.3
```
When updating the `1.20.4` release, we want this behavior and no other changes:
```
latest - v1.21.1
1      - v1.21.1
1.21   - v1.21.1
1.21.1 - v1.21.1
1.20   - v1.20.4 <--
1.20.3 - v1.20.3
1.20.4 - v1.20.4 <--
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Unit tests

3. Any docs updates needed?
No