### PR TITLE
Bump our go image to use 1.21

### DIFF
--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 AS base-builder
+FROM golang:1.21-alpine3.18 AS base-builder
 
 RUN apk add --update --no-cache \
     make \


### PR DESCRIPTION
## What was changed

The version of our golang image was bumped to provide Go version 1.21.

## Why?

We have projects that would like to make use of the new functionality provided by this release.

## Checklist

1. Closes: N/A
2. How was this tested: CI
3. Any docs updates needed? No
