### PR TITLE
Bump more Go versions to 1.21

### DIFF
--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 AS base-ci-builder
+FROM golang:1.21-alpine3.18 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,5 +1,5 @@
 ##### dockerize builder: built from source to support arm & x86 #####
-FROM golang:1.20-alpine3.18 AS dockerize-builder
+FROM golang:1.21-alpine3.18 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module docker_builds
 
-go 1.20
+go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
The previous PR (#143) missed a few image upgrades. This PR makes up for that.

Thanks @mindaugasrukas for pointing it out.