### PR TITLE
bump builder image to 1.14.3

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.2
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.3
 ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.2
 
 ##### Builder #####


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

We bumped Go to 1.21 and need to update to the new Docker image.

## Why?

Without this, the feature tests fail for the Server repo.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
