### PR TITLE
Disable sh xtrace in auto-setup.sh script

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux -o pipefail
+set -eu -o pipefail
 
 # === Auto setup defaults ===
 
@@ -100,7 +100,7 @@ wait_for_cassandra() {
     export CASSANDRA_TLS_KEY=${CASSANDRA_CERT_KEY}
     export CASSANDRA_TLS_CA=${CASSANDRA_CA}
 
-    { export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}; } 2> /dev/null
+    export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}
 
     until temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" validate-health; do
         echo 'Waiting for Cassandra to start up.'
@@ -153,7 +153,7 @@ setup_cassandra_schema() {
     export CASSANDRA_TLS_KEY=${CASSANDRA_CERT_KEY}
     export CASSANDRA_TLS_CA=${CASSANDRA_CA}
 
-    { export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}; } 2> /dev/null
+    export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}
 
     SCHEMA_DIR=${TEMPORAL_HOME}/schema/cassandra/temporal/versioned
     if [[ ${SKIP_DB_CREATE} != true ]]; then
@@ -172,7 +172,7 @@ setup_cassandra_schema() {
 
 setup_mysql_schema() {
     # TODO (alex): Remove exports
-    { export SQL_PASSWORD=${MYSQL_PWD}; } 2> /dev/null
+    export SQL_PASSWORD=${MYSQL_PWD}
 
     if [[ ${MYSQL_TX_ISOLATION_COMPAT} == true ]]; then
         MYSQL_CONNECT_ATTR=(--connect-attributes "tx_isolation=READ-COMMITTED")
@@ -203,7 +203,7 @@ setup_mysql_schema() {
 
 setup_postgres_schema() {
     # TODO (alex): Remove exports
-    { export SQL_PASSWORD=${POSTGRES_PWD}; } 2> /dev/null
+    export SQL_PASSWORD=${POSTGRES_PWD}
 
     if [[ ${DB} == "postgres12" ]]; then
       POSTGRES_VERSION_DIR=v12


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Disable xtrace in auto-setup.sh script.

## Why?
<!-- Tell your future self why have you made these changes -->
It was leaking passwords.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
https://github.com/temporalio/temporal/issues/3022

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
