### PR TITLE
Don't try to push images on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,10 +9,6 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
-    branches:
-      - main
-
 jobs:
   build-push-images:
     runs-on: ubuntu-latest-16-cores


### PR DESCRIPTION
Pushing container images requires credentials, which we won't have on PRs given this is a public repository.