### PR TITLE
Bump image versions to address curl vulnerability

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.3
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.2
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.4
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.3
 ARG SERVER_IMAGE
 ARG GOPROXY
 

--- a/docker/base-images/README.md
+++ b/docker/base-images/README.md
@@ -54,7 +54,7 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 Then run base image. For example:
 ```bash
-docker run --rm -it --platform linux/arm64 temporalio/base-server:1.1.0 uname -m
+docker run --rm -it --platform linux/arm64 temporalio/base-server:latest uname -m
 ```
 
 ### Troubleshooting

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.3
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.3
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.4
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.4
 
 ##### Builder #####
 FROM ${BASE_BUILDER_IMAGE} AS temporal-builder


### PR DESCRIPTION
## What was changed
All images were bumped to use newer versions of our base-* images 

## Why?
To address the recent curl vulnerability
