### PR TITLE
Use the latest version of our own images when reusing them

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.4
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.3
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:latest
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:latest
 ARG SERVER_IMAGE
 ARG GOPROXY
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.4
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.4
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:latest
+ARG BASE_SERVER_IMAGE=temporalio/base-server:latest
 
 ##### Builder #####
 FROM ${BASE_BUILDER_IMAGE} AS temporal-builder


### PR DESCRIPTION
## What was changed
We now use the `latest` tag as the default when referring to our own images

## Why?
This simplifies bumping image versions
