### PR TITLE
Revert "Don't try to push images on PRs (#151)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
       - release/*
+  pull_request:
+    branches:
+      - main
+
 jobs:
   build-push-images:
     runs-on: ubuntu-latest-16-cores


### PR DESCRIPTION

## What was changed
Commit ca055fd026d8ff82626fe42951580664f65f6bc5 was reverted

## Why?
This broke our CI somehow, and actions stopped running against `main`
