### PR TITLE
Remove fossa install step from base-ci-builder

### DIFF
--- a/docker/base-images/Makefile
+++ b/docker/base-images/Makefile
@@ -33,5 +33,5 @@ base-server-x:
 	docker buildx build . -f base-server.Dockerfile -t temporalio/base-server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT)
 
 base-ci-builder-x:
-	@echo CI builder is not supported because \"shellcheck\" and \"fossa\" are not available on \"linux/arm64\".
+	@echo CI builder is not supported because \"shellcheck\" is not available on \"linux/arm64\".
 

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -6,5 +6,3 @@ RUN apk add --update --no-cache \
     protobuf \
     build-base \
     shellcheck
-
-RUN wget -O- https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh


### PR DESCRIPTION
## What was changed
Remove fossa install from `base-ci-builder`

## Why?
We don't use fossa anymore, and it's actually pretty big.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
