### PR TITLE
Build an arm64 image for base-ci-builder

### DIFF
--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -31,11 +31,7 @@ jobs:
       matrix:
         # note this arch represents a single matrix option, see quotes
         arch: ["linux/amd64,linux/arm64"]
-        image: [base-server, base-builder, base-admin-tools]
-        include:
-          # build only amd64 image for base-ci-builder 
-          - arch: linux/amd64
-            image: base-ci-builder
+        image: [base-server, base-builder, base-admin-tools, base-ci-builder]
 
     steps:
       - name: Checkout repository
@@ -45,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'src/go.mod'
+          go-version-file: "src/go.mod"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -58,7 +54,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Bump version
         id: bump
         env:

--- a/docker/base-images/Makefile
+++ b/docker/base-images/Makefile
@@ -33,5 +33,4 @@ base-server-x:
 	docker buildx build . -f base-server.Dockerfile -t temporalio/base-server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT)
 
 base-ci-builder-x:
-	@echo CI builder is not supported because \"shellcheck\" is not available on \"linux/arm64\".
-
+	docker buildx build . -f base-ci-builder.Dockerfile -t temporalio/base-ci-builder:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT)


### PR DESCRIPTION
## What was changed
I've updated our makefile and github actions to build a linux/arm64 version of base-ci-builder so those of us running arm laptops can run our buildkite actions locally

## Why?
Shellcheck now has an arm64 binary so we're no longer stuck on linux/amd64
