### PR TITLE
Cache docker builder cache between runs

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -59,12 +59,23 @@ jobs:
           git submodule status temporal
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 
+      - name: Prepare Go Build Cache for Docker
+        uses: actions/cache@v3
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: Inject go-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: go-build-cache
+
       - name: Build Server Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: server.Dockerfile
@@ -72,7 +83,7 @@ jobs:
           push: true
 
       - name: Build Admin tools Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: admin-tools.Dockerfile
@@ -82,7 +93,7 @@ jobs:
           push: true
 
       - name: Build Autosetup Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: auto-setup.Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,10 +39,10 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Prepare Go Build Cache for Docker
-        uses: actions/cache@v3
+      - name: Restore Cached Docker Layers
+        uses: actions/cache/restore@v3
         with:
-          path: go-build-cache
+          path: /tmp/.buildx-cache
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       - name: Inject go-build-cache into docker
@@ -67,16 +67,30 @@ jobs:
         with:
           load: true
           set: "*.platform=linux/amd64"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}
         uses: docker/bake-action@v4
         with:
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      # This prevents the cache from growing in size indefinitely
+      - name: Move Docker Layers Cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Save Docker Layers Cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: ${{ !env.ACT }}
@@ -38,6 +38,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Prepare Go Build Cache for Docker
+        uses: actions/cache@v3
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: Inject go-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: go-build-cache
+
       - name: Prepare build args
         id: build_args
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,10 +40,11 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Restore Cached Docker Layers
+        id: restore-cache
         uses: actions/cache/restore@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-cache-go-${{ hashFiles('**/go.sum') }}
 
       - name: Prepare build args
         id: build_args
@@ -77,7 +78,7 @@ jobs:
       - name: Move Docker Layers Cache
         if: always()
         run: |
-          rm -rf /tmp/.buildx-cache
+          rm -rf /tmp/.buildx-cache || true
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Save Docker Layers Cache
@@ -85,7 +86,7 @@ jobs:
         if: always()
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-cache-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-cache-go-build-${{ hashFiles('**/go.sum') }}
 
       - name: Prepare build args
         id: build_args

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,14 +75,14 @@ jobs:
           image-name: server
 
       - name: Run Trivy vulnerability scanner on Admin Tools image
-        if: steps.build_args.outputs.push == 'true'
+        if: ${{ github.event_name == 'push' && !env.ACT }}
         uses: ./.github/actions/trivy
         with:
           image-tags: temporaliotest/admin-tools:${{ env.IMAGE_TAG }}
           image-name: admin-tools
 
       - name: Run Trivy vulnerability scanner on Auto Setup image
-        if: steps.build_args.outputs.push == 'true'
+        if: ${{ github.event_name == 'push' && !env.ACT }}
         uses: ./.github/actions/trivy
         with:
           image-tags: temporaliotest/auto-setup:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-cache-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-cache-go-build-
 
       - name: Prepare build args
         id: build_args

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Prepare build args
         id: build_args
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,11 +45,6 @@ jobs:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
-      - name: Inject go-build-cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
-        with:
-          cache-source: go-build-cache
-
       - name: Prepare build args
         id: build_args
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,13 +65,13 @@ jobs:
           set: |
             server.platform=linux/amd64
             server.cache-from=type=local,src=/tmp/.buildx-cache/server
-            server.cache-from=type=local,src=/tmp/.buildx-cache-new/server
+            server.cache-to=type=local,dest=/tmp/.buildx-cache-new/server
             admin-tools.platform=linux/amd64
             admin-tools.cache-from=type=local,src=/tmp/.buildx-cache/admin-tools
-            admin-tools.cache-from=type=local,src=/tmp/.buildx-cache-new/admin-tools
+            admin-tools.cache-to=type=local,dest=/tmp/.buildx-cache-new/admin-tools
             auto-setup.platform=linux/amd64
             auto-setup.cache-from=type=local,src=/tmp/.buildx-cache/auto-setup
-            auto-setup.cache-from=type=local,src=/tmp/.buildx-cache-new/auto-setup
+            auto-setup.cache-to=type=local,dest=/tmp/.buildx-cache-new/auto-setup
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Move Docker Layers Cache
         if: always()
         run: |
-          rm -rf /tmp/.buildx-cache || true
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          test -d /tmp/.buildx-cache && rm -rf /tmp/.buildx-cache
+          test -d /tmp/.buildx-cache-new && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Save Docker Layers Cache
         uses: actions/cache/save@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,16 @@ jobs:
         uses: docker/bake-action@v4
         with:
           load: true
-          set: "*.platform=linux/amd64"
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          set: |
+            server.platform=linux/amd64
+            server.cache-from=type=local,src=/tmp/.buildx-cache/server
+            server.cache-from=type=local,src=/tmp/.buildx-cache-new/server
+            admin-tools.platform=linux/amd64
+            admin-tools.cache-from=type=local,src=/tmp/.buildx-cache/admin-tools
+            admin-tools.cache-from=type=local,src=/tmp/.buildx-cache-new/admin-tools
+            auto-setup.platform=linux/amd64
+            auto-setup.cache-from=type=local,src=/tmp/.buildx-cache/auto-setup
+            auto-setup.cache-from=type=local,src=/tmp/.buildx-cache-new/auto-setup
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: "true"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -44,13 +44,13 @@ jobs:
           go-version-file: "src/go.mod"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -74,7 +74,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event.inputs.latest }}
 
       - name: Build and Push the image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: docker/base-images/${{ matrix.image }}.Dockerfile

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "src/go.mod"
 

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -40,13 +40,13 @@ jobs:
           ref: ${{ github.event.inputs.commit }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -59,7 +59,7 @@ jobs:
           tags: ${{ github.event.inputs.tag }}
 
       - name: Build-Push Base-* image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: docker/base-images/${{ github.event.inputs.target }}.Dockerfile

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -29,9 +29,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version-file: 'src/go.mod'
+          go-version-file: "src/go.mod"
       - name: Copy images
         env:
           COMMIT: ${{ github.event.inputs.commit }}

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/builder
 
 # cache Temporal packages as a docker layer
 COPY ./temporal/go.mod ./temporal/go.sum ./temporal/
-RUN (cd ./temporal && go mod download all)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && go mod download all)
 
 # build
 COPY ./temporal ./temporal
@@ -17,7 +17,7 @@ COPY ./temporal ./temporal
 # See the `buildvcs` Go flag: https://pkg.go.dev/cmd/go
 COPY ./.git ./.git
 COPY ./.gitmodules ./.gitmodules
-RUN (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool tdbg)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool tdbg)
 
 
 ##### Server #####

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -21,7 +21,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make tempo
 
 
 ##### Server #####
-FROM server
+# This is injected as a context via the bakefile so we don't take it as an ARG
+FROM temporaliotest/server as server
 
 ##### Temporal admin tools #####
 FROM ${BASE_ADMIN_TOOLS_IMAGE} as temporal-admin-tools

--- a/auto-setup.Dockerfile
+++ b/auto-setup.Dockerfile
@@ -1,10 +1,12 @@
 ARG GOPROXY
 
 ##### Admin Tools #####
-FROM admin-tools
+# This is injected as a context via the bakefile so we don't take it as an ARG
+FROM temporaliotest/admin-tools as admin-tools
 
 ##### Temporal server with Auto-Setup #####
-FROM server
+# This is injected as a context via the bakefile so we don't take it as an ARG
+FROM temporaliotest/server as server
 WORKDIR /etc/temporal
 
 # binaries

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -9,11 +9,11 @@ WORKDIR /home/builder
 
 # cache Temporal packages as a docker layer
 COPY ./temporal/go.mod ./temporal/go.sum ./temporal/
-RUN (cd ./temporal && go mod download all)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && go mod download all)
 
 # cache tctl packages as a docker layer
 COPY ./tctl/go.mod ./tctl/go.sum ./tctl/
-RUN (cd ./tctl && go mod download all)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./tctl && go mod download all)
 
 # install Temporal CLI
 RUN sh -c "$(curl -sSf https://temporal.download/cli.sh)" -- --dir ./cli --version "$TEMPORAL_CLI_VERSION" && \
@@ -26,8 +26,8 @@ COPY ./temporal ./temporal
 # See the `buildvcs` Go flag: https://pkg.go.dev/cmd/go
 COPY ./.git ./.git
 COPY ./.gitmodules ./.gitmodules
-RUN (cd ./temporal && make temporal-server)
-RUN (cd ./tctl && make build)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make temporal-server)
+RUN --mount=type=cache,target=/root/.cache/go-build (cd ./tctl && make build)
 
 ##### Temporal server #####
 FROM ${BASE_SERVER_IMAGE} as temporal-server


### PR DESCRIPTION
## What was changed

This preserves docker buildkit cache mounts between runs by [integrating with GHA's caching](https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api). While I was here I bumped the version of all the GHAs we use

## Why?

This should improve the performance of our build pipelines and _hopefully_ keep them from timing out rebuilding things we've built many times before.
