### PR TITLE
Don't kick off concourse builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,13 +37,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Generate a token
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private_key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Prepare build args
         id: build_args
@@ -59,7 +52,7 @@ jobs:
           TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
           echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_OUTPUT
 
-### BUILD & PUSH SERVER IMAGE ###
+      ### BUILD & PUSH SERVER IMAGE ###
 
       - name: Metatags for the Server image
         id: meta_server
@@ -89,7 +82,7 @@ jobs:
           image-tags: ${{ steps.meta_server.outputs.tags }}
           image-name: server
 
-### BUILD & PUSH ADMIN TOOLS IMAGE ###
+      ### BUILD & PUSH ADMIN TOOLS IMAGE ###
 
       - name: Metatags for the Admin Tools image
         if: steps.build_args.outputs.push == 'true'
@@ -121,22 +114,7 @@ jobs:
           image-tags: ${{ steps.meta_admin_tools.outputs.tags }}
           image-name: admin-tools
 
-      - name: Dispatch CICD
-        if: steps.build_args.outputs.push == 'true'
-        env:
-          PAT: ${{ steps.generate_token.outputs.token }}
-          PARENT_REPO: temporalio/cicd-builds
-          WORKFLOW_ID: publish-stage-results.yml
-          PARENT_BRANCH: ${{ toJSON('master') }}
-          STAGE: ${{ toJSON('builds') }}
-          COMPONENT: ${{ toJSON('temporal') }}
-          TAG: ${{ steps.build_args.outputs.image_tag }}
-          AUTHOR: ${{ toJSON(github.event.head_commit.author.name) }}
-          COMMIT_MESSAGE: ${{ toJSON(github.event.head_commit.message) }}
-        run: |
-          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "stage":'"$STAGE"', "component":'"$COMPONENT"', "image_tag":"'"$TAG"'", "commit_author":'"$AUTHOR"', "commit_message":'"$COMMIT_MESSAGE"' }}'
-
-### BUILD & PUSH AUTO SETUP IMAGE ###
+      ### BUILD & PUSH AUTO SETUP IMAGE ###
 
       - name: Metatags for the Auto Setup image
         if: steps.build_args.outputs.push == 'true'


### PR DESCRIPTION
## What was changed

We no longer kick off a concourse action when build-push-images runs.

## Why?

We're retiring concourse
