### PR TITLE
Use a docker bakefile to simplify CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest #-16-cores
     # Usually, a successful job takes ~17 mins.
     # Anything more than 30 mins is a sign that job is stuck.
     # This is a workaround until we find the root cause.
@@ -41,108 +41,39 @@ jobs:
       - name: Prepare build args
         id: build_args
         run: |
-          github_sha_short=${GITHUB_SHA:0:7}
-          push=${{ github.event_name == 'push' && !env.ACT }}
-          echo "commit_sha_short=${github_sha_short}" >> $GITHUB_OUTPUT
-          echo "image_tag=sha-${github_sha_short}" >> $GITHUB_OUTPUT
           echo "push=${push}" >> $GITHUB_OUTPUT
 
+          github_sha_short=${GITHUB_SHA:0:7}
+          echo "IMAGE_TAG=sha-${github_sha_short}" >> $GITHUB_ENV
+          push=${{ github.event_name == 'push' && !env.ACT }}
           TEMPORAL_SHA=$(git submodule status -- temporal | awk '{print $1}')
-          echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_OUTPUT
+          echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_ENV
           TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
-          echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_OUTPUT
+          echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_ENV
 
-      ### BUILD & PUSH SERVER IMAGE ###
-
-      - name: Metatags for the Server image
-        id: meta_server
-        uses: docker/metadata-action@v3
+      - name: Bake images
+        uses: docker/bake-action@v4
         with:
-          images: temporaliotest/server
-          tags: |
-            type=sha,format=short,event=branch
-            latest
+          pull: true
+          push: ${{ steps.build_args.outputs.push == 'true' }}
 
-      - name: Build-Push Server image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ steps.build_args.outputs.push }}
-          file: server.Dockerfile
-          build-args: |
-            TEMPORAL_SHA=${{ steps.build_args.outputs.TEMPORAL_SHA }}
-            TCTL_SHA=${{ steps.build_args.outputs.TCTL_SHA }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_server.outputs.tags }}
-          labels: ${{ steps.meta_server.outputs.labels }}
-
+      # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image
         uses: ./.github/actions/trivy
         with:
-          image-tags: ${{ steps.meta_server.outputs.tags }}
+          image-tags: temporaliotest/server:${{ env.IMAGE_TAG }}
           image-name: server
-
-      ### BUILD & PUSH ADMIN TOOLS IMAGE ###
-
-      - name: Metatags for the Admin Tools image
-        if: steps.build_args.outputs.push == 'true'
-        id: meta_admin_tools
-        uses: docker/metadata-action@v3
-        with:
-          images: temporaliotest/admin-tools
-          tags: |
-            type=sha,format=short,event=branch
-            latest
-
-      - name: Build-Push Admin Tools
-        if: steps.build_args.outputs.push == 'true'
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ steps.build_args.outputs.push }}
-          file: admin-tools.Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_admin_tools.outputs.tags }}
-          labels: ${{ steps.meta_admin_tools.outputs.labels }}
-          build-args: |
-            SERVER_IMAGE=temporaliotest/server:${{ steps.build_args.outputs.image_tag }}
 
       - name: Run Trivy vulnerability scanner on Admin Tools image
         if: steps.build_args.outputs.push == 'true'
         uses: ./.github/actions/trivy
         with:
-          image-tags: ${{ steps.meta_admin_tools.outputs.tags }}
+          image-tags: temporaliotest/admin-tools:${{ env.IMAGE_TAG }}
           image-name: admin-tools
-
-      ### BUILD & PUSH AUTO SETUP IMAGE ###
-
-      - name: Metatags for the Auto Setup image
-        if: steps.build_args.outputs.push == 'true'
-        id: meta_auto_setup
-        uses: docker/metadata-action@v3
-        with:
-          images: temporaliotest/auto-setup
-          tags: |
-            type=sha,format=short,event=branch
-            latest
-
-      - name: Build-Push Auto Setup
-        if: steps.build_args.outputs.push == 'true'
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ steps.build_args.outputs.push }}
-          file: auto-setup.Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_auto_setup.outputs.tags }}
-          labels: ${{ steps.meta_auto_setup.outputs.labels }}
-          build-args: |
-            SERVER_IMAGE=temporaliotest/server:${{ steps.build_args.outputs.image_tag }}
-            ADMIN_TOOLS_IMAGE=temporaliotest/admin-tools:${{ steps.build_args.outputs.image_tag }}
 
       - name: Run Trivy vulnerability scanner on Auto Setup image
         if: steps.build_args.outputs.push == 'true'
         uses: ./.github/actions/trivy
         with:
-          image-tags: ${{ steps.meta_auto_setup.outputs.tags }}
+          image-tags: temporaliotest/auto-setup:${{ env.IMAGE_TAG }}
           image-name: auto-setup

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -41,11 +42,8 @@ jobs:
       - name: Prepare build args
         id: build_args
         run: |
-          echo "push=${push}" >> $GITHUB_OUTPUT
-
           github_sha_short=${GITHUB_SHA:0:7}
           echo "IMAGE_TAG=sha-${github_sha_short}" >> $GITHUB_ENV
-          push=${{ github.event_name == 'push' && !env.ACT }}
           TEMPORAL_SHA=$(git submodule status -- temporal | awk '{print $1}')
           echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_ENV
           TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
@@ -55,7 +53,7 @@ jobs:
         uses: docker/bake-action@v4
         with:
           pull: true
-          push: ${{ steps.build_args.outputs.push == 'true' }}
+          push: ${{ github.event_name == 'push' && !env.ACT }}
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           pull: true
           push: ${{ github.event_name == 'push' && !env.ACT }}
+          load: true
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-push-images:
-    runs-on: ubuntu-latest #-16-cores
+    runs-on: ubuntu-latest-16-cores
     # Usually, a successful job takes ~17 mins.
     # Anything more than 30 mins is a sign that job is stuck.
     # This is a workaround until we find the root cause.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 	$(BAKE)
 
 verify-ci:
-	act push -j build-push-images
+	@act push -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest
 
 # We hard-code linux/amd64 here as the docker machine for mac doesn't support cross-platform builds (but it does when running verify-ci)
 docker-server:

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.4
 ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.3
-ARG SERVER_IMAGE
 ARG GOPROXY
 
 ##### Temporal Admin Tools builder #####
@@ -22,8 +21,7 @@ RUN (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool tdbg)
 
 
 ##### Server #####
-FROM ${SERVER_IMAGE} as server
-
+FROM server
 
 ##### Temporal admin tools #####
 FROM ${BASE_ADMIN_TOOLS_IMAGE} as temporal-admin-tools

--- a/auto-setup.Dockerfile
+++ b/auto-setup.Dockerfile
@@ -1,12 +1,10 @@
-ARG SERVER_IMAGE
-ARG ADMIN_TOOLS_IMAGE
 ARG GOPROXY
 
 ##### Admin Tools #####
-FROM ${ADMIN_TOOLS_IMAGE} as admin-tools
+FROM admin-tools
 
 ##### Temporal server with Auto-Setup #####
-FROM ${SERVER_IMAGE} as server
+FROM server
 WORKDIR /etc/temporal
 
 # binaries

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,74 @@
+# docker-bake.hcl
+variable "platforms" {
+  default = ["linux/amd64"]#, "linux/arm64"]
+}
+
+variable "IMAGE_TAG" {
+  default = null
+}
+
+variable "TEMPORAL_SHA" {
+  default = null
+}
+
+variable "TCTL_SHA" {
+  default = null
+}
+
+group "default" {
+  targets = [
+    "server",
+    "admin-tools",
+    "auto-setup",
+  ]
+}
+
+target "server" {
+  dockerfile = "server.Dockerfile"
+  tags = ["temporaliotest/server:${IMAGE_TAG}", "temporaliotest/server:latest"]
+  platforms = platforms
+  args = {
+    TEMPORAL_SHA = "${TEMPORAL_SHA}"
+    TCTL_SHA = "${TCTL_SHA}"
+  }
+  labels = {
+    "org.opencontainers.image.title" = "server"
+    "org.opencontainers.image.description" = "Workflow as Code (TM) to build and operate resilient applications"
+    "org.opencontainers.image.url" = "https://github.com/temporalio/temporal"
+    "org.opencontainers.image.source" = "https://github.com/temporalio/temporal"
+    "org.opencontainers.image.licenses" = "MIT"
+  }
+}
+
+target "admin-tools" {
+  dockerfile = "admin-tools.Dockerfile"
+  tags = ["temporaliotest/admin-tools:${IMAGE_TAG}", "temporaliotest/admin-tools:latest"]
+  platforms = platforms
+  contexts = {
+    server = "target:server"
+  }
+  labels = {
+    "org.opencontainers.image.title" = "admin-tools"
+    "org.opencontainers.image.description" = "Workflow as Code (TM) to build and operate resilient applications"
+    "org.opencontainers.image.url" = "https://github.com/temporalio/docker-builds"
+    "org.opencontainers.image.source" = "https://github.com/temporalio/docker-builds"
+    "org.opencontainers.image.licenses" = "MIT"
+  }
+}
+
+target "auto-setup" {
+  dockerfile = "auto-setup.Dockerfile"
+  tags = ["temporaliotest/auto-setup:${IMAGE_TAG}", "temporaliotest/auto-setup:latest"]
+  platforms = platforms
+  contexts = {
+    server = "target:server"
+    admin-tools = "target:admin-tools"
+  }
+  labels = {
+    "org.opencontainers.image.title" = "auto-setup"
+    "org.opencontainers.image.description" = "Workflow as Code (TM) to build and operate resilient applications"
+    "org.opencontainers.image.url" = "https://github.com/temporalio/docker-builds"
+    "org.opencontainers.image.source" = "https://github.com/temporalio/docker-builds"
+    "org.opencontainers.image.licenses" = "MIT"
+  }
+}


### PR DESCRIPTION
## What was changed
I replaced all our manual image build steps with a [Docker bake file](https://docs.docker.com/build/bake/) so it's easier to manage. This will let me swap in depot---or anything else that is required for all image builds---with ease.

I'll take a look at doing the same for our base images in another PR later if it makes sense.

## Why?

A declarative config file like this lets us change or add images without mucking about with the grody github actions yaml file. This will also let docker (or depot) manage parallelism and sharing better.

## Checklist

### Testing

I ran the new `make verify-ci` target and it built the images successfully.