### PR TITLE
Separate push and load steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,8 +53,15 @@ jobs:
         uses: docker/bake-action@v4
         with:
           pull: true
-          push: ${{ github.event_name == 'push' && !env.ACT }}
           load: true
+
+      # This is stupid, but you cannot specify both load and push together
+      # and we need load for trivy to work...
+      - name: Push images
+        if: ${{ github.event_name == 'push' && !env.ACT }}
+        uses: docker/bake-action@v4
+        with:
+          push: true
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image


### PR DESCRIPTION
## What was changed
We run the `bake` action twice now: once to load it locally, and a second time to push to the remote when requested.

## Why?
You cannot specify these options together: https://github.com/temporalio/docker-builds/actions/runs/6880855010/job/18715940597
