### PR TITLE
Only tag latest when we're building after a push to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: "true"
 
@@ -48,6 +48,8 @@ jobs:
           echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_ENV
           TCTL_SHA=$(git submodule status -- tctl | awk '{print $1}')
           echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_ENV
+          TAG_LATEST=${{(github.event_name == 'push' && github.ref == 'refs/heads/main') && 'true' || 'false'}}
+          echo "TAG_LATEST=${TAG_LATEST}" >> $GITHUB_ENV
 
       # You can't use `load` when building a multiarch image, so we build and load the
       # native image and build multiarch images later

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,6 +15,10 @@ variable "TCTL_SHA" {
   default = null
 }
 
+variable "TAG_LATEST" {
+  default = false
+}
+
 group "default" {
   targets = [
     "server",
@@ -25,7 +29,12 @@ group "default" {
 
 target "server" {
   dockerfile = "server.Dockerfile"
-  tags = ["temporaliotest/server:${IMAGE_TAG}", "temporaliotest/server:latest"]
+  # When building locally always tag latest. These will be overridden in CI to only
+  # conditionally tag the latest branch
+  tags = [
+    "temporaliotest/server:${IMAGE_TAG}",
+    TAG_LATEST ? "temporaliotest/server:latest" : ""
+  ]
   platforms = platforms
   args = {
     TEMPORAL_SHA = "${TEMPORAL_SHA}"
@@ -42,7 +51,10 @@ target "server" {
 
 target "admin-tools" {
   dockerfile = "admin-tools.Dockerfile"
-  tags = ["temporaliotest/admin-tools:${IMAGE_TAG}", "temporaliotest/admin-tools:latest"]
+  tags = [
+    "temporaliotest/admin-tools:${IMAGE_TAG}",
+    TAG_LATEST ? "temporaliotest/admin-tools:latest" : ""
+  ]
   platforms = platforms
   contexts = {
     server = "target:server"
@@ -58,7 +70,10 @@ target "admin-tools" {
 
 target "auto-setup" {
   dockerfile = "auto-setup.Dockerfile"
-  tags = ["temporaliotest/auto-setup:${IMAGE_TAG}", "temporaliotest/auto-setup:latest"]
+  tags = [
+    "temporaliotest/auto-setup:${IMAGE_TAG}",
+    TAG_LATEST ? "temporaliotest/auto-setup:latest" : ""
+  ]
   platforms = platforms
   contexts = {
     server = "target:server"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -29,8 +29,6 @@ group "default" {
 
 target "server" {
   dockerfile = "server.Dockerfile"
-  # When building locally always tag latest. These will be overridden in CI to only
-  # conditionally tag the latest branch
   tags = [
     "temporaliotest/server:${IMAGE_TAG}",
     TAG_LATEST ? "temporaliotest/server:latest" : ""


### PR DESCRIPTION
We need latest to be set _only_ when building against main, otherwise when we build a release image we can stomp the versions needed for nightly testing.
The bake file makes this pretty easy to do thankfully.
