### PR TITLE
Add sed to base-ci-builder

### DIFF
--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -5,4 +5,5 @@ RUN apk add --update --no-cache \
     git \
     protobuf \
     build-base \
+    sed \
     shellcheck


### PR DESCRIPTION
## What was changed
I added `sed` to our base ci builder image.

## Why?
We're beginning to use this for some nasty proto fixups and should just place it in the base image.