### PR TITLE
Correctly set the SHA when dispatched from GitHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,14 +46,9 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set SHA when dispatched
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          echo "SHA=${{github.event.inputs.commit}}" >> $GITHUB_ENV
-
-      - name: Set SHA otherwise
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: |
-          echo "SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+          SHA=$([ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && echo "${{ github.event.inputs.commit }}" || echo "${GITHUB_SHA}")
+          echo "SHA=${SHA}" >> $GITHUB_ENV
 
       - name: Prepare build args
         id: build_args

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,10 +45,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set SHA when dispatched
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "SHA=${{github.event.inputs.commit}}" >> $GITHUB_ENV
+
+      - name: Set SHA otherwise
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          echo "SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+
       - name: Prepare build args
         id: build_args
         run: |
-          github_sha_short=${GITHUB_SHA:0:7}
+          github_sha_short=${SHA:0:7}
           echo "IMAGE_TAG=sha-${github_sha_short}" >> $GITHUB_ENV
           TEMPORAL_SHA=$(git submodule status -- temporal | awk '{print $1}')
           echo "TEMPORAL_SHA=${TEMPORAL_SHA}" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ simulate-push:
 
 COMMIT =?
 simulate-dispatch:
-	@act workflow-dispatch -s GITHUB_TOKEN="$(shell gh auth token)" -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest --input commit=$(COMMIT)
+	@act workflow_dispatch -s GITHUB_TOKEN="$(shell gh auth token)" -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest --input commit=$(COMMIT)
 
 # We hard-code linux/amd64 here as the docker machine for mac doesn't support cross-platform builds (but it does when running verify-ci)
 docker-server:


### PR DESCRIPTION
## What was changed
We now correctly set the image tag when dispatched from GitHub

## Why?
It was broken before

## Testing
```
$ make COMMIT=a59209eeba62f1da800461044b23ce8b335e58c3 simulate-dispatch 2>/dev/null | rg IMAGE_TAG
[Build Docker Images/build-push-images        ]   ⚙  ::set-env:: IMAGE_TAG=sha-a59209e
```