### PR TITLE
Use the dockerhub PAT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Prepare build args
         id: build_args

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Bump version
         id: bump

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Metatags for the image
         id: meta

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -37,7 +37,7 @@ jobs:
           COMMIT: ${{ github.event.inputs.commit }}
           TAG: ${{ github.event.inputs.tag }}
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          PASSWORD: ${{ secrets.DOCKER_PAT }}
           IMAGES: server auto-setup admin-tools
           SRC_REPO: temporaliotest
           DST_REPO: temporalio

--- a/.github/workflows/update-latest-temporal.yml
+++ b/.github/workflows/update-latest-temporal.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Copy images
         env:
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          PASSWORD: ${{ secrets.DOCKER_PAT }}
           IMAGES: server auto-setup admin-tools
           REPO: temporalio
           SRC_TAG: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
## What was changed
We now use a dockerhub Personal Access Token (PAT) instead of the account password

## Why?
Over the weekend security changed our docker account to require MFA, so our automated processes need to use the PAT instead of the password
