### PR TITLE
Fix another docker pipeline

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -74,14 +74,25 @@ jobs:
         with:
           cache-source: go-build-cache
 
-      - name: Bake native images for security scanning
+      - name: Configure image variables
+        run: |
+          echo "IMAGE_TAG=sha-${github_sha_short}" >> $GITHUB_ENV
+          echo "IMAGE_REPO=temporalio" >> $GITHUB_ENV
+
+
+      - name: Bake images
         uses: docker/bake-action@v4
         with:
+          push: false
+          load: true
           set: |
             server.platform=linux/amd64
             admin-tools.platform=linux/amd64
             auto-setup.platform=linux/amd64
             auto-setup.output=type=docker,dest=/tmp/temporal-autosetup.tar
+
+      - name: Ensure images work
+        run: make IMAGE_TAG=${{env.IMAGE_TAG}} test
 
       # Upload-artifact has no good way to flatten paths, so we need to move the compose file
       # to avoid some disgustingly long inner path inside the artifact zip.

--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -70,38 +70,18 @@ jobs:
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       - name: Inject go-build-cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.3
         with:
           cache-source: go-build-cache
 
-      - name: Build Server Image
-        uses: docker/build-push-action@v5
+      - name: Bake native images for security scanning
+        uses: docker/bake-action@v4
         with:
-          context: .
-          file: server.Dockerfile
-          tags: localhost:5000/temporal-server:latest
-          push: true
-
-      - name: Build Admin tools Image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: admin-tools.Dockerfile
-          build-args: |
-            SERVER_IMAGE=localhost:5000/temporal-server:latest
-          tags: localhost:5000/temporal-admin-tools:latest
-          push: true
-
-      - name: Build Autosetup Image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: auto-setup.Dockerfile
-          build-args: |
-            SERVER_IMAGE=localhost:5000/temporal-server:latest
-            ADMIN_TOOLS_IMAGE=localhost:5000/temporal-admin-tools:latest
-          tags: temporal-autosetup:latest
-          outputs: type=docker,dest=/tmp/temporal-autosetup.tar
+          set: |
+            server.platform=linux/amd64
+            admin-tools.platform=linux/amd64
+            auto-setup.platform=linux/amd64
+            auto-setup.output=type=docker,dest=/tmp/temporal-autosetup.tar
 
       # Upload-artifact has no good way to flatten paths, so we need to move the compose file
       # to avoid some disgustingly long inner path inside the artifact zip.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           load: true
           set: |
-            server.platform=linux/amd64
-            admin-tools.platform=linux/amd64
-            auto-setup.platform=linux/amd64
+            server.platform=linux/arm64
+            admin-tools.platform=linux/arm64
+            auto-setup.platform=linux/arm64
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,30 +56,19 @@ jobs:
           echo "TCTL_SHA=${TCTL_SHA}" >> $GITHUB_ENV
           TAG_LATEST=${{(github.event_name == 'push' && github.ref == 'refs/heads/main') && 'true' || 'false'}}
           echo "TAG_LATEST=${TAG_LATEST}" >> $GITHUB_ENV
-
-          # Cache params are a bit of a pain
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-          cachefor () {
-              echo "$1.cache-from=type=local,src=/tmp/.buildx-cache/$1"
-              echo "$1.cache-to=type=local,dest=/tmp/.buildx-cache-new/$1"
-          }
-
-          echo 'cache_params<<EOF' >> $GITHUB_OUTPUT
-          for img in server admin-tools auto-setup; do
-            cachefor $img >> $GITHUB_OUTPUT
-          done
-          echo 'EOF' >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
-      - name: Restore Cached Docker Layers
-        id: restore-cache
-        uses: actions/cache/restore@v3
+      - name: Prepare Go Build Cache for Docker
+        uses: actions/cache@v3
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-cache-go-build-${{ hashFiles('**/go.sum') }}-${{steps.build_args.outputs.branch}}
-          restore-keys: |
-            ${{ runner.os }}-cache-go-build-${{ hashFiles('**/go.sum') }}-
-            ${{ runner.os }}-cache-go-build-
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: Inject go-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.3
+        with:
+          cache-source: go-build-cache
 
       # You can't use `load` when building a multiarch image, so we build and load the
       # native image and build multiarch images later
@@ -91,29 +80,12 @@ jobs:
             server.platform=linux/amd64
             admin-tools.platform=linux/amd64
             auto-setup.platform=linux/amd64
-            ${{ steps.build_args.outputs.cache_params }}
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}
         uses: docker/bake-action@v4
         with:
           push: true
-          set: |
-            ${{ steps.build_args.outputs.cache_params }}
-
-      # This prevents the cache from growing in size indefinitely
-      - name: Move Docker Layers Cache
-        if: always()
-        run: |
-          test -d /tmp/.buildx-cache && rm -rf /tmp/.buildx-cache
-          test -d /tmp/.buildx-cache-new && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      - name: Save Docker Layers Cache
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,6 +3,10 @@ variable "platforms" {
   default = ["linux/amd64", "linux/arm64"]
 }
 
+variable "IMAGE_REPO" {
+  default = "temporaliotest"
+}
+
 variable "IMAGE_TAG" {
   default = null
 }
@@ -31,8 +35,8 @@ target "server" {
   dockerfile = "server.Dockerfile"
   target = "server"
   tags = [
-    "temporaliotest/server:${IMAGE_TAG}",
-    TAG_LATEST ? "temporaliotest/server:latest" : ""
+    "${IMAGE_REPO}/server:${IMAGE_TAG}",
+    TAG_LATEST ? "${IMAGE_REPO}/server:latest" : ""
   ]
   platforms = platforms
   args = {
@@ -51,8 +55,8 @@ target "server" {
 target "admin-tools" {
   dockerfile = "admin-tools.Dockerfile"
   tags = [
-    "temporaliotest/admin-tools:${IMAGE_TAG}",
-    TAG_LATEST ? "temporaliotest/admin-tools:latest" : ""
+    "${IMAGE_REPO}/admin-tools:${IMAGE_TAG}",
+    TAG_LATEST ? "${IMAGE_REPO}/admin-tools:latest" : ""
   ]
   platforms = platforms
   contexts = {
@@ -71,8 +75,8 @@ target "auto-setup" {
   dockerfile = "server.Dockerfile"
   target = "auto-setup"
   tags = [
-    "temporaliotest/auto-setup:${IMAGE_TAG}",
-    TAG_LATEST ? "temporaliotest/auto-setup:latest" : ""
+    "${IMAGE_REPO}/auto-setup:${IMAGE_TAG}",
+    TAG_LATEST ? "${IMAGE_REPO}/auto-setup:latest" : ""
   ]
   platforms = platforms
   contexts = {


### PR DESCRIPTION
## What was changed
I have (hopefully) fixed the docker-build-only pipeline used by the server repo

## Why?
I was unaware we had yet another pipeline that runs on the server repo directly. This should use the bake action to create images and also quickly test them to ensure we've not broken anything