### PR TITLE
Tag latest when building test images

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           server_sha_short=${GITHUB_SHA:0:7}
           echo "IMAGE_TAG=sha-$(git submodule status -- temporal | cut -c2-8)" >> $GITHUB_ENV
-          echo "IMAGE_REPO=temporalio" >> $GITHUB_ENV
+          echo "TAG_LATEST=true" >> $GITHUB_ENV
 
 
       - name: Bake images
@@ -112,7 +112,7 @@ jobs:
         run: make IMAGE_TAG=${{env.IMAGE_TAG}} test
 
       - name: Save autosetup image
-        run: docker save --output="/tmp/temporal-autosetup.tar" ${{env.IMAGE_REPO}}/auto-setup:${{env.IMAGE_TAG}}
+        run: docker save --output="/tmp/temporal-autosetup.tar" temporaliotest/auto-setup:latest
 
       # Upload-artifact has no good way to flatten paths, so we need to move the compose file
       # to avoid some disgustingly long inner path inside the artifact zip.


### PR DESCRIPTION
## What was changed
I updated the docker-build-only pipeline to tag latest and use the `temporaliotest` repo instead of `temporal`

## Why?
So CI works. This pairs with https://github.com/temporalio/features/pull/386
