### PR TITLE
Update alpine to 3.19

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.18
+ARG BASE_IMAGE=alpine:3.19
 
 FROM ${BASE_IMAGE} AS builder
 

--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.18 AS base-builder
+FROM golang:1.21-alpine3.19 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.18 AS base-ci-builder
+FROM golang:1.21-alpine3.19 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,5 +1,5 @@
 ##### dockerize builder: built from source to support arm & x86 #####
-FROM golang:1.21-alpine3.18 AS dockerize-builder
+FROM golang:1.21-alpine3.19 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git
@@ -11,7 +11,7 @@ RUN mkdir -p /xsrc && \
     rm -rf /xsrc
 
 ##### base-server target #####
-FROM alpine:3.18 AS base-server
+FROM alpine:3.19 AS base-server
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
## What was changed
Alpine is upgraded from `3.18` to `3.19`

## Why?
Addresses [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363)

This should also address [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) as `dockerize` has [updated](https://github.com/jwilder/dockerize/commit/8f3785f7a523d776e680243a13263b324075b7f6) its `go.mod`, and `base-server.Dockerfile` [always pulls](https://github.com/temporalio/docker-builds/blob/2b1b5cad1964e2e16cd7c357b729cbd08d690924/docker/base-images/base-server.Dockerfile#L7-L11) the latest `main`.

## Checklist
1. Closes #180 

2. How was this tested:
Ran `make test`

3. Any docs updates needed?
None
