### PR TITLE
fix `COPY .git`

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -15,7 +15,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && go mod dow
 COPY ./temporal ./temporal
 # Git info is needed for Go build to attach VCS information properly.
 # See the `buildvcs` Go flag: https://pkg.go.dev/cmd/go
-COPY ./.git ./.git
+# NOTE: `COPY ./.git ./.git` will fail in Docker as COPY isn't allowed to add git repositories
+COPY ./.gi? ./.git
 COPY ./.gitmodules ./.gitmodules
 RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make temporal-cassandra-tool temporal-sql-tool tdbg)
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -24,7 +24,8 @@ COPY ./tctl ./tctl
 COPY ./temporal ./temporal
 # Git info is needed for Go build to attach VCS information properly.
 # See the `buildvcs` Go flag: https://pkg.go.dev/cmd/go
-COPY ./.git ./.git
+# NOTE: `COPY ./.git ./.git` will fail in Docker as COPY isn't allowed to add git repositories
+COPY ./.gi? ./.git
 COPY ./.gitmodules ./.gitmodules
 RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make temporal-server)
 RUN --mount=type=cache,target=/root/.cache/go-build (cd ./tctl && make build)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixing `COPY` for adding `.git` directories.

## Why?
<!-- Tell your future self why have you made these changes -->

https://github.com/temporalio/temporal/actions/runs/8299631664/job/22717105934?pr=5507

```
server.Dockerfile:27
--------------------
  25 |     # Git info is needed for Go build to attach VCS information properly.
  26 |     # See the `buildvcs` Go flag: https://pkg.go.dev/cmd/go
  27 | >>> COPY ./.git ./.git
  28 |     COPY ./.gitmodules ./.gitmodules
  29 |     RUN --mount=type=cache,target=/root/.cache/go-build (cd ./temporal && make temporal-server)
--------------------
ERROR: failed to solve: source can't be a git ref for COPY
Error: buildx bake failed with: ERROR: failed to solve: source can't be a git ref for COPY
```

Might be related to https://github.com/moby/buildkit/pull/4326 and https://github.com/actions/runner-images/pull/9482

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
