### PR TITLE
All docker image builds go through the makefile

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -98,7 +98,7 @@ jobs:
           echo "TAG_LATEST=true" >> $GITHUB_ENV
 
       - name: Bake images
-        run: BAKE_OUTPUT=docker make build
+        run: BAKE_OUTPUT=docker make build-native
 
       - name: Ensure images work
         run: make IMAGE_TAG=${{env.IMAGE_TAG}} test

--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -97,16 +97,8 @@ jobs:
           echo "IMAGE_TAG=sha-$(git submodule status -- temporal | cut -c2-8)" >> $GITHUB_ENV
           echo "TAG_LATEST=true" >> $GITHUB_ENV
 
-
       - name: Bake images
-        uses: docker/bake-action@v4
-        with:
-          push: false
-          load: true
-          set: |
-            server.platform=linux/amd64
-            admin-tools.platform=linux/amd64
-            auto-setup.platform=linux/amd64
+        run: BAKE_OUTPUT=docker make build
 
       - name: Ensure images work
         run: make IMAGE_TAG=${{env.IMAGE_TAG}} test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,36 +69,14 @@ jobs:
           cache-dependency-path: "**/*.sum"
           go-version-file: 'temporal/go.mod'
 
-      - name: Compile binaries
-        run: make bins
-
-      - name: Get native architecture
-        run: |
-          case ${RUNNER_ARCH} in
-            X*)
-                echo NATIVE_ARCH=amd64 >> $GITHUB_ENV
-                ;;
-            ARM*)
-                echo NATIVE_ARCH=arm64 >> $GITHUB_ENV
-                ;;
-          esac
-
       # You can't use `load` when building a multiarch image, so we build and load the
       # native image and build multiarch images later
       - name: Bake native images for security scanning
-        uses: docker/bake-action@v4
-        with:
-          load: true
-          set: |
-            server.platform=linux/${{ env.NATIVE_ARCH }}
-            admin-tools.platform=linux/${{ env.NATIVE_ARCH }}
-            auto-setup.platform=linux/${{ env.NATIVE_ARCH }}
+        run: BAKE_OUTPUT=docker make build
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}
-        uses: docker/bake-action@v4
-        with:
-          push: true
+        run: BAKE_OUTPUT=registry make build
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
       # You can't use `load` when building a multiarch image, so we build and load the
       # native image and build multiarch images later
       - name: Bake native images for security scanning
-        run: BAKE_OUTPUT=docker make build
+        run: BAKE_OUTPUT=docker make build-native
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}

--- a/Makefile
+++ b/Makefile
@@ -69,15 +69,16 @@ simulate-push:
 COMMIT =?
 .PHONY: simulate-dispatch
 simulate-dispatch:
-	@act workflow_dispatch -s GITHUB_TOKEN="$(shell gh auth token)" -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest --input commit=$(COMMIT)
+	@act workflow_dispatch -s GITHUB_TOKEN="$(shell gh auth token)" -j build-image -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest --input commit=$(COMMIT)
 
 # We hard-code the native arch here as the docker machine for mac doesn't support cross-platform builds (unless running within act)
-.PHONY: build
-build: $(NATIVE_ARCH)-bins
-	$(BAKE) --set "*.platform=linux/$(NATIVE_ARCH)" --set="*.output=type=$(BAKE_OUTPUT)"
+# This target also ignores the BAKE_OUTPUT variable to prevent us from uploading a single-architecture image
+.PHONY: build-native
+build-native: $(NATIVE_ARCH)-bins
+	$(BAKE) --set "*.platform=linux/$(NATIVE_ARCH)" --load
 
-.PHONY: build-x
-build-x: bins
+.PHONY: build
+build: bins
 	$(BAKE) --set="*.output=type=$(BAKE_OUTPUT)"
 
 .PHONY: docker-server

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY:
-
 all: install
 
 ##### Variables ######
@@ -20,17 +18,24 @@ DOCKER ?= docker buildx
 BAKE := IMAGE_TAG=$(IMAGE_TAG) TEMPORAL_SHA=$(TEMPORAL_SHA) TCTL_SHA=$(TCTL_SHA) $(DOCKER) bake
 NATIVE_ARCH := $(shell go env GOARCH)
 
+# Default to loading into the local docker context. Provide the value 'registry' if you wish to push the images
+BAKE_OUTPUT ?= docker
+
 ##### Scripts ######
+.PHONY: install
 install: install-submodules
 clean:
 	rm -rf ./build
 
+.PHONY: update
 update: update-submodules
 
+.PHONY: install-submodules
 install-submodules:
 	@printf $(COLOR) "Installing submodules..."
 	git submodule update --init
 
+.PHONY: update-submodules
 update-submodules:
 	@printf $(COLOR) "Updatinging temporal and tctl submodules..."
 	git submodule update --force --remote $(TEMPORAL_ROOT) $(TCTL_ROOT)
@@ -40,8 +45,8 @@ update-submodules:
 # If you're new to Make, this is a pattern rule: https://www.gnu.org/software/make/manual/html_node/Pattern-Rules.html#Pattern-Rules
 # $* expands to the stem that matches the %, so when the target is amd64-bins $* expands to amd64
 %-bins:
-	mkdir -p build/$*
-	cd $(DOCKERIZE_ROOT) && CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$* go build -o ../build/$*/dockerize .
+	@mkdir -p build/$*
+	@cd $(DOCKERIZE_ROOT) && CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$* go build -o ../build/$*/dockerize .
 	@GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) make -C $(TEMPORAL_ROOT) bins
 	@cp $(TEMPORAL_ROOT)/temporal-server build/$*/
 	@cp $(TEMPORAL_ROOT)/temporal-cassandra-tool build/$*/
@@ -53,46 +58,62 @@ update-submodules:
 	@cp ./$(TCTL_ROOT)/tctl build/$*/
 	@cp ./$(TCTL_ROOT)/tctl-authorization-plugin build/$*/
 
-bins: install-submodules amd64-bins arm64-bins
+.PHONY: bins
 .NOTPARALLEL: bins
+bins: install-submodules amd64-bins arm64-bins
 
+.PHONY: simulate-push
 simulate-push:
 	@act push -s GITHUB_TOKEN="$(shell gh auth token)" -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest
 
 COMMIT =?
+.PHONY: simulate-dispatch
 simulate-dispatch:
 	@act workflow_dispatch -s GITHUB_TOKEN="$(shell gh auth token)" -j build-push-images -P ubuntu-latest-16-cores=catthehacker/ubuntu:act-latest --input commit=$(COMMIT)
 
 # We hard-code the native arch here as the docker machine for mac doesn't support cross-platform builds (unless running within act)
-build: docker-server docker-admin-tools docker-auto-setup
-	$(BAKE) --set "*.platform=linux/$(NATIVE_ARCH)" --load
+.PHONY: build
+build: $(NATIVE_ARCH)-bins
+	$(BAKE) --set "*.platform=linux/$(NATIVE_ARCH)" --set="*.output=type=$(BAKE_OUTPUT)"
 
+.PHONY: build-x
+build-x: bins
+	$(BAKE) --set="*.output=type=$(BAKE_OUTPUT)"
+
+.PHONY: docker-server
 docker-server: $(NATIVE_ARCH)-bins
 	@printf $(COLOR) "Building docker image temporalio/server:$(IMAGE_TAG)..."
 	$(BAKE) server --set "*.platform=linux/$(NATIVE_ARCH)"
 
+.PHONY: docker-admin-tools
 docker-admin-tools: $(NATIVE_ARCH)-bins
 	@printf $(COLOR) "Build docker image temporalio/admin-tools:$(IMAGE_TAG)..."
 	$(BAKE) admin-tools --set "*.platform=linux/$(NATIVE_ARCH)"
 
+.PHONY: docker-auto-setup
 docker-auto-setup: $(NATIVE_ARCH)-bins
 	@printf $(COLOR) "Build docker image temporalio/auto-setup:$(IMAGE_TAG)..."
 	$(BAKE) auto-setup --set "*.platform=linux/$(NATIVE_ARCH)"
 
+.PHONY: docker-buildx-container
 docker-buildx-container:
 	docker buildx create --name builder-x --driver docker-container --use
 
+.PHONY: docker-server-x
 docker-server-x: bins
 	@printf $(COLOR) "Building cross-platform docker image temporalio/server:$(IMAGE_TAG)..."
 	$(BAKE) server
 
+.PHONY: docker-admin-tools-x
 docker-admin-tools-x: bins
 	@printf $(COLOR) "Build cross-platform docker image temporalio/admin-tools:$(IMAGE_TAG)..."
 	$(BAKE) admin-tools
 
+.PHONY: docker-auto-setup-x
 docker-auto-setup-x: bins
 	@printf $(COLOR) "Build cross-platform docker image temporalio/auto-setup:$(DOCKER_IMAGE_TAG)..."
 	$(BAKE) auto-setup
 
+.PHONY: test
 test:
 	IMAGE_TAG=$(IMAGE_TAG) ./test.sh


### PR DESCRIPTION
## What was changed

Our GHA workflows now use the makefile to build/push the image

## Why?
The Makefile is our single source of truth for how to build these images; the GHA workflows should focus on environment setup.

I don't want to see failures like https://github.com/temporalio/temporal/actions/runs/8530026612?pr=5650 again