### PR TITLE
Add cloud/* branches to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - release/*
+      - cloud/*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## What was changed
Build images from `cloud/*` branches too, as triggered by https://github.com/temporalio/temporal/pull/5696

## Why?
So we can test them
