### PR TITLE
Update GHA versions so CI stops complaining

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -49,7 +49,7 @@ jobs:
           - 5000:5000
     steps:
       - name: Checkout docker builds repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Must specify repo path, or it'll use path of calling workflow (since this is a reusable wf)
           repository: temporalio/docker-builds
@@ -112,7 +112,7 @@ jobs:
         run: cp ./temporal/develop/docker-compose/docker-compose.yml /tmp/docker-compose.yml
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: temporal-server-docker
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Upload compose logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-compose-logs
           path: docker-compose.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run ShellCheck

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "src/go.mod"
 

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}
 

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "src/go.mod"
       - name: Copy images

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -31,7 +31,7 @@ jobs:
           private_key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
           
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           persist-credentials: true


### PR DESCRIPTION
## What was changed
I updated the version of out-of-date GitHub actions as some of these will be deprecated later this year