### PR TITLE
Update submodule to specific commit

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -12,6 +12,9 @@ on:
       branch:
         description: "Branch of the submodule to update"
         required: true
+      commit:
+        description: "Commit of the submodule to check out"
+        required: false
 
 jobs:
   sync:
@@ -65,6 +68,15 @@ jobs:
           fi
           git config --file=.gitmodules submodule."$SUBMODULE".branch "$BRANCH"
           git submodule update --init --recursive --remote "$SUBMODULE"
+
+      - name: Check out requested commit
+        if:  github.event.inputs.commit
+        env:
+          SUBMODULE: ${{ github.event.inputs.repo }}
+          COMMIT: ${{ github.event.inputs.commit }}
+        run: |
+          # We know the submodule exists by this point
+          cd $(git config --file=.gitmodules --get submodule."$SUBMODULE".path) && git checkout "$COMMIT"
 
       - name: Commit update
         env:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ update-submodules:
 	@cp $(TEMPORAL_ROOT)/temporal-cassandra-tool build/$*/
 	@cp $(TEMPORAL_ROOT)/temporal-sql-tool build/$*/
 	@cp $(TEMPORAL_ROOT)/tdbg build/$*/
-	@GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) make -C $(CLI_ROOT) build
+	@cd $(CLI_ROOT) && GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) go build ./cmd/temporal
 	@cp ./$(CLI_ROOT)/temporal build/$*/
 	@GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) make -C $(TCTL_ROOT) build
 	@cp ./$(TCTL_ROOT)/tctl build/$*/


### PR DESCRIPTION
## What was changed
I added the option to specify a commit to our update submodule action

## Why?

This will allow us to update to a specific release version for
repos (e.g. the cli) that don't have release branches
