### PR TITLE
Use a separate release tag for admintools

### DIFF
--- a/.github/workflows/release-admin-tools.yml
+++ b/.github/workflows/release-admin-tools.yml
@@ -1,4 +1,4 @@
-name: Release Temporal Images
+name: Release Admin Tools Image
 
 permissions: read-all
 
@@ -6,10 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       commit:
-        description: "Commit sha"
-        required: true
-      tag:
-        description: "The tag for the new images"
+        description: "Repo Commit sha"
         required: true
       admintools_tag:
         description: "The tag for the new admintools image"
@@ -34,20 +31,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "src/go.mod"
-      - name: Copy temporal images
-        env:
-          COMMIT: ${{ github.event.inputs.commit }}
-          TAG: ${{ github.event.inputs.tag }}
-          USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_PAT }}
-          IMAGES: server auto-setup
-          SRC_REPO: temporaliotest
-          DST_REPO: temporalio
-          LATEST: ${{ github.event.inputs.latest }}
-          MAJOR: ${{ github.event.inputs.major }}
-        run: go run src/release_temporal/main.go
-      - name: Copy admintools images
+          go-version-file: "**/go.mod"
+      - name: Copy images
         env:
           COMMIT: ${{ github.event.inputs.commit }}
           TAG: ${{ github.event.inputs.admintools_tag }}

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "src/go.mod"
 


### PR DESCRIPTION
## What was changed

Our admintools image is now tagged separately from the server images. It will no longer share a version with our server images

## Why?

This allows us to release it more frequently as we want it updated when _either_ the server or our various debugging tools are updated

## Checklist

Release runbooks will be updated later today
