### PR TITLE
Use the released CLI artifacts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,10 +74,14 @@ jobs:
       # native image and build multiarch images later
       - name: Bake native images for security scanning
         run: BAKE_OUTPUT=docker make build-native
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bake and push multiarch images
         if: ${{ github.event_name == 'push' && !env.ACT }}
         run: BAKE_OUTPUT=registry make build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ update-submodules:
 	@cp ./$(TCTL_ROOT)/tctl build/$*/
 	@cp ./$(TCTL_ROOT)/tctl-authorization-plugin build/$*/
 	@gh release -R temporalio/cli download $(CLI_VER) -p "*linux_$(*).tar.gz" -O - | tar --to-stdout -z -x -v -f - temporal > build/$*/temporal
+	@chmod +x build/$*/temporal
 
 .PHONY: bins
 .NOTPARALLEL: bins


### PR DESCRIPTION
## What was changed

We use the pre-built CLI artifacts from the official releases rather than compiling them ourselves

## Why?

Calculating the CLI's version based on the tag is a pain (see https://github.com/temporalio/docker-builds/pull/203) and I don't want to do that in our Makefile, so we're going to download the appropriate artifact from the official release instead

## Note

This is gross but it works. I'm putting this up to stimulate discussion on how we _should_ do it.