### PR TITLE
Ensure binaries are rebuilt when target changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ update-submodules:
 %-bins:
 	@mkdir -p build/$*
 	@cd $(DOCKERIZE_ROOT) && CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$* go build -o ../build/$*/dockerize .
-	@GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) make -C $(TEMPORAL_ROOT) bins
+	@GOOS=linux GOARCH=$* CGO_ENABLED=$(CGO_ENABLED) make -C $(TEMPORAL_ROOT) clean-bins bins
 	@cp $(TEMPORAL_ROOT)/temporal-server build/$*/
 	@cp $(TEMPORAL_ROOT)/temporal-cassandra-tool build/$*/
 	@cp $(TEMPORAL_ROOT)/temporal-sql-tool build/$*/


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Clean binaries before compiling.
<!-- Describe what has changed in this PR -->

## Why?
Changing the OS/arch does not cause make to recompile binaries. This meant whichever arch was compiled first would then be used in place of all the others. Cleaning the binaries before compiling ensures we build for the correct arch.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #194

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested using `file build/amd64/*` and `file build/arm64/*` before and after the fix to ensure the binaries were for the correct architecture.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
