### PR TITLE
Don't ignore fatal errors from auto-setup.sh

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -92,7 +92,7 @@ validate_db_env() {
           fi
           ;;
       *)
-          die "Unsupported DB type: ${DB}."
+          die "Unsupported driver specified: 'DB=${DB}'. Valid drivers are: mysql8, postgres12, postgres12_pgx, cassandra."
           ;;
     esac
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,12 +27,27 @@ fi
 dockerize -template /etc/temporal/config/config_template.yaml:/etc/temporal/config/docker.yaml
 
 # Automatically setup Temporal Server (databases, Elasticsearch, default namespace) if "autosetup" is passed as an argument.
-for arg; do [[ ${arg} == autosetup ]] && /etc/temporal/auto-setup.sh && break ; done
+for arg; do
+    if [[ ${arg} == autosetup ]]; then
+        /etc/temporal/auto-setup.sh
+        break
+    fi
+done
 
 # Setup Temporal Server in development mode if "develop" is passed as an argument.
-for arg; do [[ ${arg} == develop ]] && /etc/temporal/setup-develop.sh && break ; done
+for arg; do
+    if [[ ${arg} == develop ]]; then
+        /etc/temporal/setup-develop.sh
+        break
+    fi
+done
 
 # Run bash instead of Temporal Server if "bash" is passed as an argument (convenient to debug docker image).
-for arg; do [[ ${arg} == bash ]] && bash && exit 0 ; done
+for arg; do
+    if [[ ${arg} == bash ]]; then
+        bash
+        exit 0
+    fi
+done
 
 exec /etc/temporal/start-temporal.sh


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Don't continue to start the Temporal Server if auto-setup.sh returns an error.
Improved the database driver validation error message.
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->
Starting the server when auto-setup.sh found an error obscures the error message from auto-setup.sh, making it harder for users to understand what is wrong.
Also try to make it clearer that DB= sets the driver type, and report the valid values.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Used the modified image to start badly configured containers and check the error reporting is clearer.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
