### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -111,7 +111,7 @@ jobs:
           echo -n "${{env.IMAGE_TAG}}" > /tmp/image_tag
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: temporal-server-docker
           path: |


### PR DESCRIPTION
Bump `actions/upload-artifact` to `v4` in `.github/workflows/docker-build-only.yml`

https://github.com/temporalio/features/pull/491 bumped the download side to v4, but we also need to bump the upload side as well 

Should address errors like

```
Error: Unable to download artifact(s): Artifact not found for name: temporal-server-docker
```

example: https://github.com/temporalio/temporal/actions/runs/9424005363/job/25963539180?pr=6087

Note: I am only doing it for this workflow since I don't have context on how the other ones are used.

Should be safe to bump this since the only uses are in this repo and the main server repo https://github.com/search?q=org%3Atemporalio%20.github%2Fworkflows%2Fdocker-build-only.yml&type=code
