### PR TITLE
Default broadcast address to primary IP if binding on all interfaces

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,11 @@ set -eu -o pipefail
 : "${BIND_ON_IP:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
 export BIND_ON_IP
 
+if [[ "${BIND_ON_IP}" == "0.0.0.0" ]]; then
+    : "${TEMPORAL_BROADCAST_ADDRESS:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
+    export TEMPORAL_BROADCAST_ADDRESS
+fi
+
 # check TEMPORAL_ADDRESS is not empty
 if [[ -z "${TEMPORAL_ADDRESS:-}" ]]; then
     echo "TEMPORAL_ADDRESS is not set, setting it to ${BIND_ON_IP}:7233"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Set a sensible default for broadcast address if BIND_ON_IP is 0.0.0.0.

<!-- Describe what has changed in this PR -->

## Why?
We require broadcast address to be set if listening on all interfaces, but it is not possible for users to know which IP they will have via environment variables on all platforms.


<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Tested by two users on slack replacing their custom docker images that set TEMPORAL_BROADCAST_ADDRESS for them.
Also note this only sets TEMPORAL_BROADCAST_ADDRESS if it isn't already set and BIND_ON_IP=0.0.0.0 which is a known broken configuration anyway.

<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
