### PR TITLE
Verify binaries are for correct platform

### DIFF
--- a/src/image_copy/main.go
+++ b/src/image_copy/main.go
@@ -70,8 +70,8 @@ func getTags(dstTag string, updateMajor bool) []string {
 	return tags
 }
 
-func verifyImage(imageTag, platform, check string) {
-	fmt.Printf("verifying binaries in '%s' from '%s' for platform '%s' are '%s'\n", binFolder, imageTag, platform, check)
+func mustHaveArchitecture(imageTag, platform, expectedArch string) {
+	fmt.Printf("verifying binaries in '%s' from '%s' for platform '%s' are '%s'\n", binFolder, imageTag, platform, expectedArch)
 
 	cmd := exec.Command(
 		"docker",
@@ -88,10 +88,10 @@ count=0
 for file in `+binFolder+`/*; do
   if [ -f "$file" ]; then
     count=$((count+1))
-    if file "$file" | grep -q "`+check+`"; then
-      echo "$file is `+check+`"
+    if file "$file" | grep -q "`+expectedArch+`"; then
+      echo "$file is `+expectedArch+`"
     else
-      echo "$file is not `+check+`"
+      echo "$file is not `+expectedArch+`"
       file "$file"
       exit 1
     fi
@@ -119,8 +119,8 @@ func copyImages() {
 
 	for _, image := range env.images {
 		src := fmt.Sprintf("%s/%s:%s", env.srcRepo, image, env.srcTag)
-		verifyImage(src, "linux/arm64", "ARM")
-		verifyImage(src, "linux/amd64", "x86")
+		mustHaveArchitecture(src, "linux/arm64", "ARM")
+		mustHaveArchitecture(src, "linux/amd64", "x86")
 
 		srcWithProto := fmt.Sprintf("docker://%s", src)
 		destCreds := fmt.Sprintf("--dest-creds=%s:%s", env.username, env.password)

--- a/src/image_copy/main.go
+++ b/src/image_copy/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -103,12 +102,8 @@ if [ $count -lt 1 ]; then
   exit 1
 fi
 `)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err := cmd.Run()
-	fmt.Println(out.String())
+	out, err := cmd.CombinedOutput()
+	fmt.Println(string(out))
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add verification step for Docker images before releasing them.

PS: I didn't add this to the _build_ step because the risk is high that it would fail silently without anyone noticing.

## Why?
<!-- Tell your future self why have you made these changes -->

To ensure we release the right binary for each platform.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Running from terminal:

**Pass**
```
DST_REPO=temporalio SRC_REPO=temporaliotest PASSWORD=wrong USERNAME=wrong IMAGES=server TAG=dummy COMMIT=bc8c2cd1928c4a6dd3330b48a370cf2c10672968 go run src/image_copy/main.go

verifying binaries in '/usr/local/bin' from 'temporaliotest/server:sha-bc8c2cd' for platform 'linux/arm64' are 'ARM'
Unable to find image 'temporaliotest/server:sha-bc8c2cd' locally
sha-bc8c2cd: Pulling from temporaliotest/server
Digest: sha256:aefb7a40c9bb176e96fb4611c3349631afe61a48b6094be551f2e475d9dccdd6
Status: Downloaded newer image for temporaliotest/server:sha-bc8c2cd
/usr/local/bin/dockerize is ARM
/usr/local/bin/tctl is ARM
/usr/local/bin/tctl-authorization-plugin is ARM
/usr/local/bin/temporal is ARM
/usr/local/bin/temporal-server is ARM

verifying binaries in '/usr/local/bin' from 'temporaliotest/server:sha-bc8c2cd' for platform 'linux/amd64' are 'x86'
Unable to find image 'temporaliotest/server:sha-bc8c2cd' locally
sha-bc8c2cd: Pulling from temporaliotest/server
Digest: sha256:aefb7a40c9bb176e96fb4611c3349631afe61a48b6094be551f2e475d9dccdd6
Status: Downloaded newer image for temporaliotest/server:sha-bc8c2cd
/usr/local/bin/dockerize is x86
/usr/local/bin/tctl is x86
/usr/local/bin/tctl-authorization-plugin is x86
/usr/local/bin/temporal is x86
/usr/local/bin/temporal-server is x86
```

**Fail**
```
DST_REPO=temporalio SRC_REPO=temporaliotest PASSWORD=wrong USERNAME=wrong IMAGES=server TAG=dummy COMMIT=e3ae365 go run src/image_copy/main.go                                 

verifying binaries in '/usr/local/bin' from 'temporaliotest/server:sha-e3ae365' for platform 'linux/arm64' are 'ARM'
/usr/local/bin/dockerize is ARM
/usr/local/bin/tctl is ARM
/usr/local/bin/tctl-authorization-plugin is ARM
/usr/local/bin/temporal is ARM
/usr/local/bin/temporal-server is not ARM
/usr/local/bin/temporal-server: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=zYjsJtF6wN_KxfTbdu3M/JvdfsrR994VzMaLyzT7r/zPP_QXPvSn-BxercUyWN/93737e5xSZZUcGmDZcrc, with debug_info, not stripped

2024/06/21 13:50:04 exit status 1
exit status 1
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
