### PR TITLE
Use arm64 for release workflows

### DIFF
--- a/.github/workflows/release-admin-tools.yml
+++ b/.github/workflows/release-admin-tools.yml
@@ -18,10 +18,42 @@ on:
         default: false
 
 jobs:
+  verify-arm64:
+    name: "Verify images are ARM"
+    runs-on: ubuntu-24.04-arm64-2-core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "src/go.mod"
+      - name: Verify image binaries
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
+          IMAGES: admin-tools
+          SRC_REPO: temporaliotest
+          ARCH: "ARM"
+        run: go run src/image_verify/main.go
+
+  verify-x86:
+    name: "Verify images are x86"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "src/go.mod"
+      - name: Verify image binaries
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
+          IMAGES: admin-tools
+          SRC_REPO: temporaliotest
+          ARCH: "x86"
+        run: go run src/image_verify/main.go
+
   retag-and-release:
     name: "Re-tag and release images"
     runs-on: ubuntu-latest
-
+    needs: [verify-arm64, verify-x86]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -23,10 +23,42 @@ on:
         default: false
 
 jobs:
+  verify-arm64:
+    name: "Verify images are ARM"
+    runs-on: ubuntu-24.04-arm64-2-core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "src/go.mod"
+      - name: Verify image binaries
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
+          IMAGES: server auto-setup
+          SRC_REPO: temporaliotest
+          ARCH: "ARM"
+        run: go run src/image_verify/main.go
+
+  verify-x86:
+    name: "Verify images are x86"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "src/go.mod"
+      - name: Verify image binaries
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
+          IMAGES: server auto-setup
+          SRC_REPO: temporaliotest
+          ARCH: "x86"
+        run: go run src/image_verify/main.go
+
   retag-and-release:
     name: "Re-tag and release images"
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04-arm64-2-core
+    needs: [verify-arm64, verify-x86]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/src/image_verify/main.go
+++ b/src/image_verify/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const binFolder = "/usr/local/bin"
+
+type Env struct {
+	images  []string
+	srcRepo string
+	srcTag  string
+	arch    string
+}
+
+func loadEnv() *Env {
+	commit := getEnv("COMMIT")
+	return &Env{
+		images:  strings.Split(getEnv("IMAGES"), " "),
+		srcRepo: getEnv("SRC_REPO"),
+		srcTag:  fmt.Sprintf("sha-%s", commit[0:7]),
+		arch:    getEnv("ARCH"),
+	}
+}
+
+func getEnv(key string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		log.Fatalf("Required env %q not set\n", key)
+	}
+	return val
+}
+
+func mustHaveArchitecture(imageTag, expectedArch string) {
+	fmt.Printf("verifying binaries in '%s' from '%s' are '%s'\n", binFolder, imageTag, expectedArch)
+
+	cmd := exec.Command(
+		"docker",
+		"run",
+		"--user=root",
+		"--rm",
+		"--entrypoint=sh",
+		imageTag,
+		"-c", `
+apk add -U file > /dev/null
+
+count=0
+for file in `+binFolder+`/*; do
+  if [ -f "$file" ]; then
+    count=$((count+1))
+    if file "$file" | grep -q "`+expectedArch+`"; then
+      echo "$file is `+expectedArch+`"
+    else
+      echo "$file is not `+expectedArch+`"
+      file "$file"
+      exit 1
+    fi
+  fi
+done
+
+if [ $count -lt 1 ]; then
+  echo "no binaries were found"
+  exit 1
+fi
+`)
+	out, err := cmd.CombinedOutput()
+	fmt.Println(string(out))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func verifyImages() {
+	env := loadEnv()
+
+	for _, image := range env.images {
+		src := fmt.Sprintf("%s/%s:%s", env.srcRepo, image, env.srcTag)
+		mustHaveArchitecture(src, env.arch)
+	}
+}
+
+func main() {
+	verifyImages()
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Split Docker image verification of the platform into separate jobs that use the correct platform runner.

See last failure: https://github.com/temporalio/docker-builds/actions/runs/9877925793/job/27280692360

## Why?
<!-- Tell your future self why have you made these changes -->

Previously merged https://github.com/temporalio/docker-builds/pull/223 needs to be run from an arm64 because it needs to be able to run arm64.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
