### PR TITLE
Pin Python3 to 3.11 in base-admin-tools

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -2,7 +2,10 @@ ARG BASE_IMAGE=alpine:3.20
 
 FROM ${BASE_IMAGE} AS builder
 
+# Need to pin Python3 until the following issue is resolved, otherwise cqlsh wont work
+# https://issues.apache.org/jira/browse/CASSANDRA-19206
 RUN apk add --update --no-cache \
+    python3~3.11 \
     py3-pip \
     python3-dev \
     musl-dev \


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Need to pin Python3 until the following issue is resolved, otherwise cqlsh wont work
https://issues.apache.org/jira/browse/CASSANDRA-19206

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
