### PR TITLE
Revert "Pin Python3 to 3.11 in base-admin-tools"

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -2,10 +2,7 @@ ARG BASE_IMAGE=alpine:3.20
 
 FROM ${BASE_IMAGE} AS builder
 
-# Need to pin Python3 until the following issue is resolved, otherwise cqlsh wont work
-# https://issues.apache.org/jira/browse/CASSANDRA-19206
 RUN apk add --update --no-cache \
-    python3~3.11 \
     py3-pip \
     python3-dev \
     musl-dev \


### PR DESCRIPTION
Reverts temporalio/docker-builds#231

apk cannot install python 3.11 as it conflicts with the system-installed python 3.12.