### PR TITLE
Install Python 3.11.9 on base-admin-tools so cqlsh can run

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -2,7 +2,10 @@ ARG BASE_IMAGE=alpine:3.20
 
 FROM ${BASE_IMAGE} AS builder
 
+# Need to pin Python3 until the following issue is resolved, otherwise cqlsh wont work
+# https://issues.apache.org/jira/browse/CASSANDRA-19206
 RUN apk add --update --no-cache \
+    python3~3.11 \
     py3-pip \
     python3-dev \
     musl-dev \

--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -2,17 +2,31 @@ ARG BASE_IMAGE=alpine:3.20
 
 FROM ${BASE_IMAGE} AS builder
 
-# Need to pin Python3 until the following issue is resolved, otherwise cqlsh wont work
+# Alpine v3.20 comes with Python 3.12. But cqlsh won't work with Python 3.12 until the following issue is resolved.
 # https://issues.apache.org/jira/browse/CASSANDRA-19206
+# Compiling Python 3.11.9 from source and installing it on the side. Then creating a venv using that python version.
+# Revert this change once the issue mentioned above is resolved.
 RUN apk add --update --no-cache \
-    python3~3.11 \
-    py3-pip \
-    python3-dev \
     musl-dev \
     libffi-dev \
-    gcc
+    gcc \
+    make \
+    zlib-dev \
+    openssl-dev
 
-RUN python3 -m venv /opt/venv
+RUN mkdir -p /opt/python/3.11.9 ; \
+    cd /opt/python/3.11.9/ ; \
+    wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz -P . ; \
+    tar zxvf Python-3.11.9.tgz ; \
+    cd Python-3.11.9 ; \
+    ./configure --prefix=/opt/python/3.11.9; \
+    make ; \
+    make install ; \
+    make clean ; \
+    cd .. ; \
+    rm -rf Python-3.11.9*
+
+RUN cd /opt/python/3.11.9/bin ; ./python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install cqlsh
 
@@ -31,6 +45,7 @@ RUN apk add --update --no-cache \
     expat \
     tini
 
+COPY --from=builder /opt/python/3.11.9 /opt/python/3.11.9
 COPY --from=builder /opt/venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Alpine v3.20 comes with Python 3.12. But cqlsh won't work with Python 3.12 until the following issue is resolved.
https://issues.apache.org/jira/browse/CASSANDRA-19206
Compiling Python 3.11.9 from source and installing it on the side. Then creating a venv using that python version.
Revert this change once the issue mentioned above is resolved.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
