### PR TITLE
Default TEMPORAL_BROADCAST_ADDRESS to primary IP if BIND_ON_IP is ::1

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 : "${BIND_ON_IP:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
 export BIND_ON_IP
 
-if [[ "${BIND_ON_IP}" == "0.0.0.0" ]]; then
+if [[ "${BIND_ON_IP}" == "0.0.0.0" || "${BIND_ON_IP}" == "::0" ]]; then
     : "${TEMPORAL_BROADCAST_ADDRESS:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
     export TEMPORAL_BROADCAST_ADDRESS
 fi


### PR DESCRIPTION
It was implemented earlier for ipv4 only at https://github.com/temporalio/docker-builds/commit/527db58331aa95dc0f6816517e5502b95127192c

This commit adds support for ipv6