### PR TITLE
Use uid 2000, not 1000, for GKE compatibility

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -21,8 +21,8 @@ COPY  ./temporal/schema /etc/temporal/schema
 # Completion for temporal depends on the bash-completion package.
 RUN apk add bash-completion && \
     temporal completion bash > /etc/bash/temporal-completion.sh && \
-    addgroup -g 1000 temporal && \
-    adduser -u 1000 -G temporal -D temporal
+    addgroup -g 2000 temporal && \
+    adduser -u 2000 -G temporal -D temporal
 USER temporal
 WORKDIR /etc/temporal
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -11,8 +11,8 @@ ENV TEMPORAL_HOME=/etc/temporal
 EXPOSE 6933 6934 6935 6939 7233 7234 7235 7239
 
 # TODO switch WORKDIR to /home/temporal and remove "mkdir" and "chown" calls.
-RUN addgroup -g 1000 temporal
-RUN adduser -u 1000 -G temporal -D temporal
+RUN addgroup -g 2000 temporal
+RUN adduser -u 2000 -G temporal -D temporal
 RUN mkdir /etc/temporal/config
 RUN chown -R temporal:temporal /etc/temporal/config
 USER temporal


### PR DESCRIPTION
On GCP (and hence GKE), user IDs in the range 2000 to 4999 are available for custom users:
https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#using_cloud-init_with_the_cloud_config_format

> Choose an ID from the [2000, 4999] range to avoid collision with other
> user accounts.

This lets us use `runAsNonRoot` / `runAsUser` in a Kubernetes deployment, and I don't think (I hope?) most people won't care that the user ID changed.

Happy to just do this ourselves if we need to, but I figured it was worth a try upstream 🙂 