### PR TITLE
Fix base builder go images

### DIFF
--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-alpine3.21 AS base-builder
+FROM golang:1.23.4-alpine3.21 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-alpine3.21 AS base-ci-builder
+FROM golang:1.23.4-alpine3.21 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \


### PR DESCRIPTION
In #254 I accidentally references invalid `golang` images, this fixes the issue.