### PR TITLE
Accept `DB=postgres13`

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -92,7 +92,7 @@ validate_db_env() {
           fi
           ;;
       *)
-          die "Unsupported driver specified: 'DB=${DB}'. Valid drivers are: mysql8, postgres12, postgres12_pgx, cassandra."
+          die "Unsupported driver specified: 'DB=${DB}'. Valid drivers are: mysql8, postgres12, postgres12_pgx, postgres13, postgres13_pgx, cassandra."
           ;;
     esac
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Updated the hardcoded list of supported "DB drivers" to support postgres13.

## Why?
<!-- Tell your future self why have you made these changes -->

Postgres 13.4 is the latest officially supported version of Postgres; there is a hardcoded string check that prevents this from working in auto-setup.
https://docs.temporal.io/clusters#dependency-versions

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

- 258: https://github.com/temporalio/docker-builds/issues/258

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I wasn't, but postgres13.4 is officially supported. 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
