### PR TITLE
Simpler cqlsh installation in base-admin-tools image

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -2,37 +2,21 @@ ARG BASE_IMAGE=alpine:3.21
 
 FROM ${BASE_IMAGE} AS builder
 
-# Alpine v3.20 comes with Python 3.12. But cqlsh won't work with Python 3.12 until the following issue is resolved.
-# https://issues.apache.org/jira/browse/CASSANDRA-19206
-# Compiling Python 3.11.9 from source and installing it on the side. Then creating a venv using that python version.
-# Revert this change once the issue mentioned above is resolved.
+# These are necessary to install cqlsh
 RUN apk add --update --no-cache \
+    python3-dev \
     musl-dev \
-    libffi-dev \
+    libev-dev \
     gcc \
-    make \
-    zlib-dev \
-    openssl-dev
+    pipx
 
-RUN mkdir -p /opt/python/3.11.9 ; \
-    cd /opt/python/3.11.9/ ; \
-    wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz -P . ; \
-    tar zxvf Python-3.11.9.tgz ; \
-    cd Python-3.11.9 ; \
-    ./configure --prefix=/opt/python/3.11.9; \
-    make ; \
-    make install ; \
-    make clean ; \
-    cd .. ; \
-    rm -rf Python-3.11.9*
-
-RUN cd /opt/python/3.11.9/bin ; ./python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-RUN pip3 install cqlsh
+RUN pipx install --global cqlsh
 
 FROM ${BASE_IMAGE} AS base-admin-tools
 
 RUN apk add --update --no-cache \
+    python3 \
+    libev \
     ca-certificates \
     tzdata \
     bash \
@@ -41,16 +25,13 @@ RUN apk add --update --no-cache \
     yq \
     mysql-client \
     postgresql-client \
-    py3-pip \
     expat \
     tini
 
-COPY --from=builder /opt/python/3.11.9 /opt/python/3.11.9
-COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /opt/pipx/venvs/cqlsh /opt/pipx/venvs/cqlsh
+RUN ln -s /opt/pipx/venvs/cqlsh/bin/cqlsh /usr/local/bin/cqlsh
 
-ENV PATH="/opt/venv/bin:$PATH"
-
-# validate installation
+# validate cqlsh installation
 RUN cqlsh --version
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Install `cqlsh` using `pipx` and dependencies to be build from source works with Python 3.12.

## Why?
<!-- Tell your future self why have you made these changes -->
`cqlsh` with Python3.12 doesn't work out-of-box because `asyncore` module was removed from Python3.12, and the default built of `cqlsh` doesn't include the alternative `libev`.

However, it works if we can install it by building from source with libev (https://datastax-oss.atlassian.net/browse/PYTHON-1376).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
