### PR TITLE
Install dockerize in base-server image

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -14,7 +14,8 @@ RUN pipx install --global cqlsh
 
 FROM ${BASE_IMAGE} AS base-admin-tools
 
-RUN apk add --update --no-cache \
+RUN apk upgrade --no-cache
+RUN apk add --no-cache \
     python3 \
     libev \
     ca-certificates \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -2,14 +2,9 @@ ARG BASE_IMAGE=alpine:3.21
 
 FROM golang:1.23-alpine3.21 AS builder
 
-RUN apk add --update --no-cache \
-    git
-
 ARG DOCKERIZE_VERSION=v0.9.2
-RUN git clone https://github.com/jwilder/dockerize.git && \
-    cd dockerize && \
-    git checkout ${DOCKERIZE_VERSION} && \
-    CGO_ENABLED=0 go build -a -o /usr/local/bin/dockerize .
+RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION}
+RUN cp $(which dockerize) /usr/local/bin/dockerize
 
 ##### base-server target #####
 FROM ${BASE_IMAGE} AS base-server

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,12 +1,26 @@
 ARG BASE_IMAGE=alpine:3.21
 
+FROM golang:1.23-alpine3.21 AS builder
+
+RUN apk add --update --no-cache \
+    git
+
+ARG DOCKERIZE_VERSION=v0.9.2
+RUN git clone https://github.com/jwilder/dockerize.git && \
+    cd dockerize && \
+    git checkout ${DOCKERIZE_VERSION} && \
+    CGO_ENABLED=0 go build -a -o /usr/local/bin/dockerize .
+
 ##### base-server target #####
 FROM ${BASE_IMAGE} AS base-server
 
-RUN apk add --update --no-cache \
+RUN apk upgrade --no-cache
+RUN apk add --no-cache \
     ca-certificates \
     tzdata \
     bash \
     curl
+
+COPY --from=builder /usr/local/bin/dockerize /usr/local/bin
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Install `dockerize` in `base-server` image.
After a new image of `base-server` is released, I'll remove the `dockerize` submodule.

## Why?
<!-- Tell your future self why have you made these changes -->
It was changed in https://github.com/temporalio/docker-builds/pull/190 to be build locally and only installed in the `server` and `auto-setup` images to be faster.
However, building and installing `dockerize` in `base-server` is quick (~8s locally linux/arm64), and `base-server` is not released often.
By doing this, we can remove the `dockerize` submodule.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
