### PR TITLE
Skip checking symlinks when checking binary files

### DIFF
--- a/src/image_copy/main.go
+++ b/src/image_copy/main.go
@@ -119,7 +119,16 @@ func mustHaveArchitecture(imageTag, platform, expectedArch string) {
 		log.Fatal("no binaries were found")
 	}
 	for _, file := range files {
-		out = execCmd("file", filepath.Join(tmpDir, file.Name()))
+		fp := filepath.Join(tmpDir, file.Name())
+		info, err := os.Lstat(fp)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			// skip symlinks
+			continue
+		}
+		out = execCmd("file", fp)
 		if !strings.Contains(out, expectedArch) {
 			log.Fatal(file.Name() + " is NOT " + expectedArch)
 		} else {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Skip checking symlinks when checking binary files

## Why?
<!-- Tell your future self why have you made these changes -->
When copying docker images from the `temporaliotest` registry to `temporalio`, it checks the binaries inside the container matches the respective platform architecture. However symlinks can't be verified with `file` command.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
