### PR TITLE
only add custom search attributes if there was a default namespace

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -408,10 +408,9 @@ setup_server(){
 
     if [[ ${SKIP_DEFAULT_NAMESPACE_CREATION} != true ]]; then
         register_default_namespace
-    fi
-
-    if [[ ${SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES} != true ]]; then
-        add_custom_search_attributes
+        if [[ ${SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES} != true ]]; then
+            add_custom_search_attributes
+        fi
     fi
 }
 


### PR DESCRIPTION

## What was changed
only add custom search attributes if there was a default namespace

## Why?
because search attributes depend on a namespace

## Checklist
<!--- add/delete as needed --->

1. Closes - nothing, just stumbled on the bug while fixing something else.

2. How was this tested:
Samples-server repo

3. Any docs updates needed?
I don't think so. 
