### PR TITLE
Update CODEOWNERS to match current team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @temporalio/server will be requested for
 # review when someone opens a pull request.
-*       @temporalio/server @temporalio/devex
+*       @temporalio/server @temporalio/selfhosted


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
I changed the name of the team from "devex" to "selfhosted"

## Why?
<!-- Tell your future self why have you made these changes -->

![image](https://github.com/user-attachments/assets/1366055a-964a-4545-ade5-6f9cec2fe63f)

The file was invalid because "devex" is not the name of a team within temporalio org in GitHub. It was the name at the time this file was created, but the DevEx team was later renamed to SelfHosted, and this file was not updated to reflect that
