### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/src"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directories:
+      "/"
+      "/docker/base-images"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## What was changed
Add Dependabot configuration to look at Docker in the right place.

## Why?
This makes more sense than Trivy, if they are equivalent. Also the Trivy output format is old and unfriendly compared to Dependabot's now extremely natively integrated handling.

On merge this is supposed to run a scan, so if it pops up some more findings then I will open another PR to remove the Trivy action and I'll go clean out the old tool settings in this repo.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
