### PR TITLE
Update Alpine base image, and add a script to do so automatically

### DIFF
--- a/bin/update-alpine.sh
+++ b/bin/update-alpine.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Tag order returned will always be `latest`, `X.Y.Z`, `X.Y`, `X`. We want X.Y (e.g., 3.22).
+ALPINE_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/library/alpine/tags/?page_size=50" | jq -r '.results[2].name')
+
+# Update both BASE_IMAGE= and FROM statements.
+find . -name "*.Dockerfile" | xargs sed -i '' -E "s/alpine:[0-9.]+/alpine:${ALPINE_VERSION}/g; s/alpine[0-9.]+/alpine${ALPINE_VERSION}/g"
+
+echo "Updated Alpine version to ${ALPINE_VERSION} in all Dockerfiles"

--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.21
+ARG BASE_IMAGE=alpine:3.22
 
 FROM ${BASE_IMAGE} AS builder
 

--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.21 AS base-builder
+FROM golang:1.23.4-alpine3.22 AS base-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.21 AS base-ci-builder
+FROM golang:1.23.4-alpine3.22 AS base-ci-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE=alpine:3.21
+ARG BASE_IMAGE=alpine:3.22
 
-FROM golang:1.23-alpine3.21 AS builder
+FROM golang:1.23-alpine3.22 AS builder
 
 ARG DOCKERIZE_VERSION=v0.9.2
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION}


### PR DESCRIPTION
## What was changed
- Do an update of our Alpine base image
- Add a script to do so automatically

## Checklist
2. How was this tested:
`cd docker/base-images && make`

3. Any doc updates?
Will update release engineer notes.
