### PR TITLE
Bump Go version for newer Alpine

### DIFF
--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.22 AS base-builder
+FROM golang:1.24-alpine3.22 AS base-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.22 AS base-ci-builder
+FROM golang:1.24-alpine3.22 AS base-ci-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=alpine:3.22
 
-FROM golang:1.23-alpine3.22 AS builder
+FROM golang:1.24-alpine3.22 AS builder
 
 ARG DOCKERIZE_VERSION=v0.9.2
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION}


### PR DESCRIPTION
## What was changed
- Bumped Go version.

## Why?
1.23 doesn't have an alpine3.22 tag.
