### PR TITLE
Update Dockerfiles to use latest Temporal base, add a script to do it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,8 @@ update-alpine:
 	@printf $(COLOR) "Updating base images to latest the latest Alpine image..."
 	./scripts/update-alpine.sh
 
+.PHONY: update-base-images
+update-base-images:
+	@printf $(COLOR) "Updating builds to use latest Temporal base images.."
+	./scripts/update-base-images.sh
+

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.11
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.12
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG

--- a/scripts/update-base-images.sh
+++ b/scripts/update-base-images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Tag order returned will always be `latest`, `X.Y.Z`, `X.Y`, `X`. We want X.Y.Z (e.g., 1.15.11).
+BASE_SERVER_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/temporalio/base-server/tags/?page_size=5" | jq -r '.results[1].name')
+BASE_TOOLS_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/temporalio/base-admin-tools/tags/?page_size=5" | jq -r '.results[1].name')
+
+# Update Dockerfile references throughout.
+find . -name "*.Dockerfile" -print0 | xargs -0 sed -i '' -E "s/temporalio\/base-server:[0-9.]+/temporalio\/base-server:${BASE_SERVER_VERSION}/g; s/temporalio\/base-admin-tools:[0-9.]+/temporalio\/base-admin-tools:${BASE_TOOLS_VERSION}/g"
+
+echo "Updated server base image version to ${BASE_SERVER_VERSION} and admin tools base image version to ${BASE_TOOLS_VERSION}."

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.11
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.12
 
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TARGETARCH


### PR DESCRIPTION
## What was changed
- Updated server and admin-tools to use our latest released base images
- Add a script and makefile target to do more of the same
