### PR TITLE
Fix image branch tag sanitization

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,8 @@ jobs:
         if: ${{ github.event_name == 'push' && !env.ACT }}
         run: |
           BAKE_OUTPUT=registry make build
-          echo "::notice title=🐳 Docker images::$(docker images --format "{{.Repository}}:{{.Tag}}" | grep temporaliotest | tr '\n' ' ')"
+          IMAGES=$(docker images --format "• {{.Repository}}:{{.Tag}}" | grep temporaliotest | tr '\n' ' ')
+          echo "::notice title=🐳 Docker images::${IMAGES}"
 
       # TODO: can we loop this somehow?
       - name: Run Trivy vulnerability scanner on Server image

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,25 +7,17 @@ variable "IMAGE_REPO" {
   default = "temporaliotest"
 }
 
-variable "IMAGE_SHA_TAG" {
-  default = null
-}
+variable "IMAGE_SHA_TAG" {}
 
-variable "IMAGE_BRANCH_TAG" {
-  default = null
-}
+variable "IMAGE_BRANCH_TAG" {}
 
 variable "SAFE_IMAGE_BRANCH_TAG" {
-  default = IMAGE_BRANCH_TAG != null ? replace(lower(IMAGE_BRANCH_TAG), "/[^a-z0-9._-]/", "-") : null
+  default = join("-", [for c in regexall("[a-z0-9]+", lower(IMAGE_BRANCH_TAG)) : c])
 }
 
-variable "TEMPORAL_SHA" {
-  default = null
-}
+variable "TEMPORAL_SHA" {}
 
-variable "TCTL_SHA" {
-  default = null
-}
+variable "TCTL_SHA" {}
 
 variable "TAG_LATEST" {
   default = false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixed the HCL regex that's used for sanitizing the branch name to be an allowed Docker image tag.

## Why?
<!-- Tell your future self why have you made these changes -->

Sanitization wasn't working. [[failed build](https://github.com/temporalio/docker-builds/actions/runs/16224800990/job/45814093495)]

## Checklist
<!--- add/delete as needed --->

Tested on this branch which is named `feature/Tes.ting+`:


<img width="2084" height="157" alt="Screenshot 2025-07-11 at 10 41 46 AM" src="https://github.com/user-attachments/assets/0854a753-d8a5-4e53-ae42-4b0dcdc1f703" />
