### PR TITLE
Update CODEOWNERS to remove DevEx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @temporalio/server will be requested for
 # review when someone opens a pull request.
-*       @temporalio/server @temporalio/devex
+*       @temporalio/server


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I removed the DevEx team. 


## Why?
<!-- Tell your future self why have you made these changes -->
This is not a valid team in the temporalio organization, so its inclusion made the file invalid (as shown below). It was valid at the time that it was added, but was later renamed to `selfhosted`. However, Rob Holland and I recently discussed this and concluded that DevRel (of which selfhosted is a subset) should not be the owners. Consequently, removing the group resolves both issues. 

<img width="589" height="405" alt="image" src="https://github.com/user-attachments/assets/8bdd24ee-6c31-4fd1-83e7-89e12fdf9451" />


