### PR TITLE
Replace nc -z with pg_isready for PostgreSQL readiness check

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -124,8 +124,11 @@ wait_for_mysql() {
 }
 
 wait_for_postgres() {
-    until nc -z "${POSTGRES_SEEDS%%,*}" "${DB_PORT}"; do
-        echo 'Waiting for PostgreSQL to startup.'
+    local host="${POSTGRES_SEEDS%%,*}"
+    local user="${POSTGRES_USER:-temporal}"
+
+    until pg_isready -h "${host}" -p "${DB_PORT}" -U "${user}" -q; do
+        echo 'Waiting for PostgreSQL to be ready to accept connections...'
         sleep 1
     done
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -47,6 +47,10 @@ ENTRYPOINT ["/etc/temporal/entrypoint.sh"]
 FROM temporaliotest/admin-tools AS admin-tools
 FROM temporal-server AS auto-setup
 
+USER root
+RUN apk add --no-cache postgresql-client
+USER temporal
+
 WORKDIR /etc/temporal
 
 # binaries


### PR DESCRIPTION
## Summary

- **Replace `nc -z` with `pg_isready`** in the `wait_for_postgres()` function (`docker/auto-setup.sh`). `nc -z` only checks whether the TCP port is open, which can return success before PostgreSQL is actually ready to accept queries (e.g., during crash recovery or startup). `pg_isready` is the official PostgreSQL client utility that performs a proper connection readiness check—it returns exit code 0 only when the server is accepting connections.
- **Add `postgresql-client` package** to the `auto-setup` stage in `server.Dockerfile` to make `pg_isready` available at runtime.

## Motivation

In environments where PostgreSQL takes time to initialize (large databases, slow storage, replicas catching up), `nc -z` can prematurely report the database as ready. This causes `temporal-sql-tool` schema setup commands to fail because the port is open but PostgreSQL is still in recovery. Using `pg_isready` eliminates this race condition.

## Test plan

- [ ] `make build-native` — confirm Docker images build successfully with the new `postgresql-client` package
- [ ] `make test` — runs docker-compose integration test (PostgreSQL backend by default), confirming the readiness check works end-to-end
- [ ] Verify `pg_isready` correctly waits when PostgreSQL is slow to start (e.g., by delaying PostgreSQL startup in compose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)