### PR TITLE
Update base images and trivy scanner for v1.28.x

### DIFF
--- a/.github/actions/trivy/action.yml
+++ b/.github/actions/trivy/action.yml
@@ -23,7 +23,7 @@ runs:
         name=${NAME// /-}
         echo "tag=${tag}" >> $GITHUB_OUTPUT
         echo "name=${name}" >> $GITHUB_OUTPUT
-      
+
     - name: Install ORAS
       id: oras
       uses: oras-project/setup-oras@v1
@@ -39,28 +39,34 @@ runs:
       id: pull
       shell: bash
       run: |
+        mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
         oras pull ghcr.io/temporalio/trivy-db:2
+        tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+        rm db.tar.gz
+
+        mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
         oras pull ghcr.io/temporalio/trivy-java-db:1
+        tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+        rm javadb.tar.gz
+
+    - name: Install Trivy
+      uses: aquasecurity/setup-trivy@v0.2.5
+      with:
+        version: v0.69.3
 
     - name: Scan Container Image
       id: scan
-      uses: aquasecurity/trivy-action@0.28.0
+      shell: bash
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/temporalio/private-actions/trivy-db,public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/temporalio/private-actions/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
-        # Not 100% sure if these are required, but so far no issues.
-        TRIVY_USERNAME: ${{ github.actor }}
-        TRIVY_PASSWORD: ${{ github.token }}
-      with:
-        cache: true
-        exit-code: 0
-        image-ref: ${{ steps.vars.outputs.tag }}
-        format: 'sarif'
-        output: 'trivy-${{ steps.vars.outputs.name }}-results.sarif'
+        TRIVY_SKIP_DB_UPDATE: true
+        TRIVY_SKIP_JAVA_DB_UPDATE: true
+        TRIVY_CACHE_DIR: ${{ github.workspace }}/.cache/trivy
+      run: |
+        trivy image --severity HIGH,CRITICAL --no-progress ${{ steps.vars.outputs.tag }} --format sarif --output trivy-${{ steps.vars.outputs.name }}-results.sarif
 
-    - name: Upload ${{ inputs.image-name }} image Trivy scan results to GitHub Security tab
+    - name: Upload Trivy scan results
       uses: github/codeql-action/upload-sarif@v3
-      #if: always()
+      if: always()
       with:
-        sarif_file: 'trivy-${{ steps.vars.outputs.name }}-results.sarif'
+        sarif_file: trivy-${{ steps.vars.outputs.name }}-results.sarif
         category: trivy-${{ steps.vars.outputs.name }}-results

--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.16
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.18
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.16
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.18
 
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

- Bump `base-server` from 1.15.16 to 1.15.18
- Bump `base-admin-tools` from 1.12.16 to 1.12.18
- Replace `aquasecurity/trivy-action@0.28.0` with `aquasecurity/setup-trivy@v0.2.5` (Trivy v0.69.3) using direct CLI invocation and proper DB extraction

Mirrors the changes from release/v1.29.x (#311, #312).

## Test plan

- [ ] CI trivy scan runs successfully with updated action
- [ ] Docker images build with new base images