### PR TITLE
fix: revert ES_VERSION to v7 for v1.28.x compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - POSTGRES_SEEDS=postgresql
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
-      - ES_VERSION=v8
+      - ES_VERSION=v7
     image: ${IMAGE_REPO}/auto-setup:${IMAGE_TAG}
     networks:
       - temporal-network


### PR DESCRIPTION
## Summary

Reverts `ES_VERSION` from `v8` back to `v7` in `docker-compose.yml`.

PR #315 set `ES_VERSION=v8` (mirroring the v1.29.x fix), but v1.28.x auto-setup only contains v7 schema files (`cluster_settings_v7.json`, `index_template_v7.json`). With `ES_VERSION=v8`, auto-setup tries to load `cluster_settings_v8.json` which doesn't exist, causing:

```
curl: Failed to open
curl: /etc/temporal/schema/elasticsearch/visibility/cluster_settings_v8.json
```

The correct config for v1.28.x is:
- `ELASTICSEARCH_VERSION=8.5.0` (run ES 8.5.0 — from PR #315)
- `ES_VERSION=v7` (use v7 schema files — ES 8.x is backwards-compatible)

This is blocking Docker image promotion for v1.28.3.

## Test plan
- [ ] CI "Ensure images work" step passes

Made with [Cursor](https://cursor.com)