### PR TITLE
Bump base images for v1.29.6.1 security release

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.20
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.21
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.20
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.22
 
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TARGETARCH


### PR DESCRIPTION
Update `BASE_SERVER_IMAGE` and `BASE_ADMIN_TOOLS_IMAGE` references on `release/v1.29.x` to pick up Alpine package updates (notably `nghttp2-libs` 1.68.0 → 1.68.1, fixing CVE-2026-27135 High).

## Why
v1.29.6 production image flags `nghttp2-libs` High in Grype.

## Verification
- ✅ `temporalio/base-server:1.15.22` — Grype: 0 vulnerabilities
- ✅ `temporalio/base-admin-tools:1.12.21` — Grype: 0 vulnerabilities
