### PR TITLE
VLN-1387: remediate missing-dependency-cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,23 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/src"
+    cooldown:
+      default-days: 14
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directories:
       "/"
       "/docker/base-images"
+    cooldown:
+      default-days: 14
     schedule:
-      interval: "daily"
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 14
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>missing-dependency-cooldown</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/docker-builds</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1387">VLN-1387</a></td></tr>
</table>

## Summary

- `.github/dependabot.yml`: Updated all existing Dependabot ecosystems to use weekly schedules and added `cooldown: default-days: 14` for each; added a new `github-actions` ecosystem entry with weekly schedule and 14-day cooldown.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix