### PR TITLE
VLN-1355: remediate unpinned-github-actions

### DIFF
--- a/.github/actions/trivy/action.yml
+++ b/.github/actions/trivy/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Install ORAS
       id: oras
-      uses: oras-project/setup-oras@v1
+      uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
     - name: Authenticate to GHCR
       env:
@@ -50,7 +50,7 @@ runs:
         rm javadb.tar.gz
 
     - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.3
+      uses: aquasecurity/setup-trivy@9ea583eb67910444b1f64abf338bd2e105a0a93d # v0.2.3
       with:
         version: v0.65.0
 
@@ -65,7 +65,7 @@ runs:
         trivy image --severity HIGH,CRITICAL --no-progress ${{ steps.vars.outputs.tag }} --format sarif --output trivy-${{ steps.vars.outputs.name }}-results.sarif
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
       if: always()
       with:
         sarif_file: trivy-${{ steps.vars.outputs.name }}-results.sarif

--- a/.github/workflows/docker-build-only.yml
+++ b/.github/workflows/docker-build-only.yml
@@ -55,7 +55,7 @@ jobs:
           sudo rm -rf /opt/microsoft/powershell || :
           df -h
       - name: Checkout docker builds repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Must specify repo path, or it'll use path of calling workflow (since this is a reusable wf)
           repository: temporalio/docker-builds
@@ -81,13 +81,13 @@ jobs:
           cd ..
           git submodule status temporal
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           cache-dependency-path: "**/*.sum"
           go-version-file: 'temporal/go.mod'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: network=host
 
@@ -122,7 +122,7 @@ jobs:
           echo -n "${{env.IMAGE_SHA_TAG}}" > /tmp/image_sha_tag
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: temporal-server-docker
           path: |

--- a/.github/workflows/docker-pr-compat.yml
+++ b/.github/workflows/docker-pr-compat.yml
@@ -14,16 +14,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: "true"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver: docker
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           cache-dependency-path: "**/*.sum"
           go-version-file: "temporal/go.mod"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,20 +32,20 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: "true"
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || '' }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to DockerHub
         if: ${{ !env.ACT }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PAT }}
@@ -76,7 +76,7 @@ jobs:
           TAG_LATEST=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'true' || 'false' }}
           echo "TAG_LATEST=${TAG_LATEST}" >> $GITHUB_ENV
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           cache-dependency-path: "**/*.sum"
           go-version-file: 'temporal/go.mod'
@@ -118,7 +118,7 @@ jobs:
       - name: Upload compose logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-compose-logs
           path: docker-compose.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
       - name: Run ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        uses: redhat-plumbers-in-action/differential-shellcheck@ac4483d8c6713bd2011037f44fe626989468af74 # v4.2.2
         with:
           include-path: ./docker

--- a/.github/workflows/release-admin-tools.yml
+++ b/.github/workflows/release-admin-tools.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "src/go.mod"
       - name: Copy admintools image

--- a/.github/workflows/release-all-base-image.yml
+++ b/.github/workflows/release-all-base-image.yml
@@ -36,22 +36,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "src/go.mod"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PAT }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Metatags for the image
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242 # v3.8.0
         with:
           images: temporalio/${{ matrix.image }}
           tags: |
@@ -75,7 +75,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event.inputs.latest }}
 
       - name: Build and Push the image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: true
           pull: true

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -36,31 +36,31 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
           ref: ${{ github.event.inputs.commit }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: Metatags for the image
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242 # v3.8.0
         with:
           images: temporalio/${{ github.event.inputs.target }}
           tags: ${{ github.event.inputs.tag }}
 
       - name: Build-Push Base-* image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: true
           pull: true

--- a/.github/workflows/release-temporal.yml
+++ b/.github/workflows/release-temporal.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "src/go.mod"
       - name: Copy temporal images

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate a token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
             tctl
             cli
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
           submodules: true
           persist-credentials: false


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>HIGH</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/docker-builds</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1355">VLN-1355</a></td></tr>
</table>

## Summary

- `.github/workflows/docker-build-only.yml`: Pinned all non-local action `uses:` refs to full 40-character SHAs and added exact semver inline comments.
- `.github/workflows/docker-pr-compat.yml`: Pinned all non-local action `uses:` refs to full 40-character SHAs and added exact semver inline comments.
- `.github/workflows/docker.yml`: Pinned all non-local action `uses:` refs to full 40-character SHAs and added exact semver inline comments; left local composite action refs unchanged.
- `.github/workflows/lint.yml`: Pinned `actions/checkout` and `redhat-plumbers-in-action/differential-shellcheck` to full SHAs with exact semver comments.
- `.github/workflows/release-admin-tools.yml`: Pinned `actions/checkout` and `actions/setup-go` to full SHAs with exact semver comments.
- `.github/workflows/release-all-base-image.yml`: Pinned all non-local action `uses:` refs to full 40-character SHAs and added exact semver inline comments.
- `.github/workflows/release-base-image.yml`: Pinned all non-local action `uses:` refs to full 40-character SHAs and added exact semver inline comments.
- `.github/workflows/release-temporal.yml`: Pinned `actions/checkout` and `actions/setup-go` to full SHAs with exact semver comments.
- `.github/workflows/update-submodules.yml`: Pinned `actions/create-github-app-token` and `actions/checkout` to full SHAs with exact semver comments.
- `.github/actions/trivy/action.yml`: Pinned all third-party action `uses:` refs in the composite action to full 40-character SHAs with exact semver inline comments.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix