### PR TITLE
Bump Go to 1.25.11 in base images for v1.29.7 security release

### DIFF
--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-alpine3.23 AS base-builder
+FROM golang:1.25.11-alpine3.23 AS base-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-alpine3.23 AS base-ci-builder
+FROM golang:1.25.11-alpine3.23 AS base-ci-builder
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=alpine:3.23.4
 
-FROM golang:1.25.9-alpine3.23 AS builder
+FROM golang:1.25.11-alpine3.23 AS builder
 
 ARG DOCKERIZE_VERSION=v0.11.0
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION}


### PR DESCRIPTION
## What was changed

  Bumps the bundled `golang:X-alpineY` FROM tag from `golang:1.25.9-alpine3.23` to `golang:1.25.11-alpine3.23` in 3 base Dockerfiles:

  - `docker/base-images/base-builder.Dockerfile`
  - `docker/base-images/base-ci-builder.Dockerfile`
  - `docker/base-images/base-server.Dockerfile`

  `docker/base-images/base-admin-tools.Dockerfile` is unchanged — it has no `golang:` FROM line (admin-tools doesn't compile Go at build time).

  Alpine pin stays at `3.23.4` (already on the latest 3.23.x patch). The Alpine OS package fixes flow in automatically via the existing `apk upgrade --no-cache` step that all base images run.

  Phase 1 of 2 for v1.29.7. Phase 2 PR will bump `BASE_SERVER_IMAGE` / `BASE_ADMIN_TOOLS_IMAGE` ARG defaults in `server.Dockerfile` + `admin-tools.Dockerfile` to reference the newly-published
  base image tags once `release-all-base-image.yml` releases them.

  ## Why?

  Required to clear HIGH/CRITICAL CVE findings on `temporaliotest/server:sha-5e6b469` and `temporaliotest/admin-tools:sha-5e6b469` for the v1.29.7 OSS security patch:

  **Go stdlib (fixed by 1.25.9 → 1.25.11):**
  - CVE-2026-42504, CVE-2026-42507, CVE-2026-27145
  - GO-2026-5037, -5038, -5039 (newer batch)
  - GO-2026-4986, -4977, -4971, -4980, -4981, -4982, -4918, -4976
  - Plus stdlib HIGH CVEs CVE-2026-39820, -39836, -42499, -42501, -33811, -33814, -39825, -39817, -39819, -39823, -39826

  **Alpine OS packages (flow in via `apk upgrade --no-cache` on rebuild — 3.23.4 already has the fixes):**
  - `curl` / `libcurl` 8.17.0-r1 → 8.19.0-r0 (CVE-2026-1965, -3805, -3783, -3784, -14524, -14017, -14819)
  - `libpq` / `postgresql18-client` 18.3-r0 → 18.4-r0 (CVE-2026-6473, -6475, -6477, -6479, -6637, -6638, -6476, -6478, -6472, -6474, -6575)
  - `mariadb-client` / `mariadb-common` / `mysql-client` 11.4.10-r0 → 11.4.12-r0 (CVE-2026-44168, -44169, -44170, -44171, -44172, -44173, -48163, -48165)