### PR TITLE
Bump base images for v1.29.7 security release

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.21
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.22
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.22
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.23
 
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TARGETARCH


### PR DESCRIPTION
## What changed
Bumps the `BASE_SERVER_IMAGE` and `BASE_ADMIN_TOOLS_IMAGE` ARG defaults in the root server and admin-tools Dockerfiles:
- `temporalio/base-server:1.15.22` → `1.15.23`
- `temporalio/base-admin-tools:1.12.21` → `1.12.22`

These new base images were published from #329 (Phase 1 — Go 1.25.11 + Alpine 3.23.4 rebuild) via release-all-base-image.yml on `release/v1.29.x` HEAD.

## Why
Final step in Phase 2 of the v1.29.7 security patch — gets the new Go toolchain + updated Alpine package versions into the server.Dockerfile and admin-tools.Dockerfile builds. Same shape as #324 (the v1.29.6.1 precedent).