### PR TITLE
Bump dockerize to v0.13.0 in base-server for v1.29.7

### DIFF
--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=alpine:3.23.4
 
 FROM golang:1.25.11-alpine3.23 AS builder
 
-ARG DOCKERIZE_VERSION=v0.11.0
+ARG DOCKERIZE_VERSION=v0.13.0
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION}
 RUN cp $(which dockerize) /usr/local/bin/dockerize
 


### PR DESCRIPTION
Bumps jwilder/dockerize from v0.11.0 to v0.13.0 in base-server.Dockerfile. Clears grype findings on the dockerize binary embedded in the server runtime image (x/crypto, x/net, x/sys CVEs flagged on the v0.11.0 release). Follow-on to #329 + #330 — after merge, will need release-all-base-image.yml dispatch + another BASE_SERVER_IMAGE bump in server.Dockerfile.