### PR TITLE
Bump base images for dockerize v0.13.0 (v1.29.7 follow-on)

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.22
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.23
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.23
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.24
 
 FROM ${BASE_SERVER_IMAGE} as temporal-server
 ARG TARGETARCH


### PR DESCRIPTION
Follow-on to #331 (which bumped dockerize from v0.11.0 to v0.13.0).