### PR TITLE
Install yq from upstream releases instead of Alpine apk

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -23,11 +23,19 @@ RUN apk add --no-cache \
     bash \
     curl \
     jq \
-    yq \
     mysql-client \
     postgresql-client \
     expat \
     tini
+
+# Install yq directly from upstream releases rather than the Alpine apk package.
+# The Alpine package lags upstream and ships older Go + x/net versions that
+# trigger HIGH/CRITICAL grype findings; the upstream release tracks current Go.
+ARG TARGETARCH
+ARG YQ_VERSION=v4.53.3
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/yq \
+    && /usr/local/bin/yq --version
 
 COPY --from=builder /opt/pipx/venvs/cqlsh /opt/pipx/venvs/cqlsh
 RUN ln -s /opt/pipx/venvs/cqlsh/bin/cqlsh /usr/local/bin/cqlsh


### PR DESCRIPTION
Replaces \`apk add yq\` with a direct download from mikefarah/yq/releases at v4.53.3.