### PR TITLE
Bump BASE_ADMIN_TOOLS_IMAGE to 1.12.24

### DIFF
--- a/admin-tools.Dockerfile
+++ b/admin-tools.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.23
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.12.24
 
 ##### Admin Tools #####
 # This is injected as a context via the bakefile so we don't take it as an ARG


### PR DESCRIPTION
Picks up the new base-admin-tools image (1.12.24) with yq v4.53.3 installed from upstream releases.